### PR TITLE
KB Category: Added editor for KB categories

### DIFF
--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -1,6 +1,16 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
-<h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+<div class="d-flex">
+    <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+    {% if user|is_helpdesk_staff %}
+    <div class="flex-fill d-flex justify-content-end">
+        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        </a>
+    </div>
+    {% endif %}
+</div>
+
 {% endblock %}
 
 <div class="container-fluid">

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -25,8 +25,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -16,7 +16,7 @@
         <div class="panel panel-default">
             <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
                 {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
                 <form method='post'>
@@ -34,4 +34,11 @@
             </div>
         </div>
     </div>
+
+    <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+    </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -1,0 +1,37 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -293,6 +293,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.category,
             name='kb_category'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
+            kb.edit_category,
+            name="edit_kb_category"),
+
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,
             name='kb_vote'),

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -87,29 +87,16 @@ def edit_category(request, slug):
         form = EditKBCategoryForm(request.POST, slug)
 
         if form.is_valid():
-            name = form.cleaned_data['name']
-            title = form.cleaned_data['title']
-            #slug = form.cleaned_data['slug']
-            preview_description = form.cleaned_data['preview_description']
-            description = form.cleaned_data['description']
-            queue = form.cleaned_data['queue']
-            forms = form.cleaned_data['forms']
-            public = form.cleaned_data['public']
+            category.name = form.cleaned_data['name']
+            category.title = form.cleaned_data['title']
+            # slug = form.cleaned_data['slug']
+            category.preview_description = form.cleaned_data['preview_description']
+            category.description = form.cleaned_data['description']
+            category.queue = form.cleaned_data['queue']
+            category.forms.set(form.cleaned_data['forms'])
+            category.public = form.cleaned_data['public']
 
-            new_category = KBCategory(
-                id = category.id,
-                organization = category.organization,
-                name = name, 
-                title = title, 
-                slug = category.slug, 
-                preview_description = preview_description,
-                description = description,
-                queue = queue,
-                public = public
-            )
-            category.delete()
-            new_category.save()
-            new_category.forms.set(forms)
+            category.save()
         return HttpResponseRedirect(reverse('helpdesk:kb_category', args=[category.slug]))
 
 def article(request, slug, pk, iframe=False):


### PR DESCRIPTION
Task [#1409](https://clearlyenergy.plan.io/issues/1409):
- Added edit button to the right of the KB category title inside its page.
- Opens full-page form that allows users to edit the properties of the KB category except for the slug. The organization field is hidden.