### PR TITLE
KB Article: Added editor for KB articles

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -273,6 +273,28 @@ class EditKBCategoryForm(forms.ModelForm):
         self.fields['queue'].queryset = Queue.objects.filter(organization=org)
         self.fields['forms'].queryset = FormType.objects.filter(organization=org) 
 
+class EditKBItemForm(forms.ModelForm):
+
+    class CategoryModelChoiceField(forms.ModelChoiceField):
+        def label_from_instance(self, category):
+            return "%s" % (category.name)
+        
+    category = CategoryModelChoiceField(queryset=KBCategory.objects)
+
+    class Meta:
+        model = KBItem
+        exclude = ('voted_by', 'downvoted_by', 'votes', 'recommendations', 'last_updated','team')
+
+    def __init__(self, *args, **kwargs):
+        """
+            Category field will only show category titles.
+            Filter categories by current org.
+        """
+        super(EditKBItemForm, self).__init__(*args, **kwargs)
+
+        slug = kwargs['initial']['category'].slug if kwargs else args[1]
+        org = KBCategory.objects.filter(slug=slug).first().organization
+        self.fields['category'].queryset = KBCategory.objects.filter(organization=org)
 
 class AbstractTicketForm(CustomFieldMixin, forms.Form):
     """

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -1,8 +1,15 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
 <div class="row" style="display:inline">
-    <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
-    <a style="vertial-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
+    <div class="d-flex">
+        <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
+        <div class="flex-fill d-flex justify-content-end">
+            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
+                <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+            </a>
+        </div>
+    </div>
+    <a style="vertical-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
         <i class="fa fa-angle-double-left"></i> Previous Item
     </a>
     <a class="btn btn-secondary btn-sm{% if not next_item %} disabled{% endif %}" href="{{ next_item.get_absolute_url }}/{{ user_info.url }}">

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -1,0 +1,40 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">
+    <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} Edit: {{ itemq }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -19,7 +19,7 @@
         <div class="panel panel-default">
             <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
                 {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
                 <form method='post'>
@@ -37,4 +37,11 @@
             </div>
         </div>
     </div>
+
+    <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+    </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -28,8 +28,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -1,6 +1,16 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
-<h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+<div class="d-flex">
+    <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+    {% if user|is_helpdesk_staff %}
+    <div class="flex-fill d-flex justify-content-end">
+        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        </a>
+    </div>
+    {% endif %}
+</div>
+
 {% endblock %}
 
 <div class="container-fluid">

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -25,8 +25,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -1,0 +1,37 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -293,6 +293,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.category,
             name='kb_category'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
+            kb.edit_category,
+            name="edit_kb_category"),
+
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,
             name='kb_vote'),

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -289,6 +289,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.article,
             name='kb_article'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/edit/$',
+            kb.edit_article,
+            name="edit_kb_article"),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -158,6 +158,11 @@ def article(request, slug, pk, iframe=False):
         'kb_forms': kb_forms
     })
 
+@helpdesk_staff_member_required
+def edit_article(request, slug, pk, iframe=False):
+
+    # Stub return
+    return
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -18,8 +18,10 @@ from helpdesk import settings as helpdesk_settings
 from helpdesk import user
 from helpdesk.models import KBCategory, KBItem
 from helpdesk.decorators import is_helpdesk_staff, helpdesk_staff_member_required
-from helpdesk.forms import EditKBCategoryForm
+from helpdesk.forms import EditKBCategoryForm, EditKBItemForm
 from django.utils.html import escape
+
+import datetime
 
 def index(request):
     huser = user.huser_from_request(request)
@@ -160,9 +162,56 @@ def article(request, slug, pk, iframe=False):
 
 @helpdesk_staff_member_required
 def edit_article(request, slug, pk, iframe=False):
+    item = get_object_or_404(KBItem, pk=pk)
 
-    # Stub return
-    return
+    if request.method == "GET":
+        form = EditKBItemForm(initial={
+            'category': item.category,
+            'title': item.title,
+            'question': item.question,
+            'answer': item.answer,
+            'order': item.order,
+            'enabled': item.enabled,
+        })
+
+        return render(request, 'helpdesk/kb_article_edit.html', {
+            'category': item.category,
+            'item': item,
+            'form': form,
+            'debug': settings.DEBUG,
+        })
+    elif request.method == "POST":
+        form = EditKBItemForm(request.POST, item.category.slug)
+
+        if form.is_valid():
+            category = form.cleaned_data['category']
+            title = form.cleaned_data['title']
+            question = form.cleaned_data['question']
+            answer = form.cleaned_data['answer']
+            order = form.cleaned_data['order']
+            enabled = form.cleaned_data['enabled']
+            voted_by = item.voted_by
+            downvoted_by = item.downvoted_by
+
+            new_item = KBItem(
+                id = item.id,
+                category = category,
+                title = title,
+                question = question,
+                answer = answer,
+                order = order,
+                enabled = enabled,
+                votes = item.votes,
+                recommendations = item.recommendations,
+                team = item.team,
+                last_updated = datetime.datetime.now()
+            )
+            item.delete()
+            new_item.save()
+            new_item.voted_by.set(voted_by.all())
+            new_item.downvoted_by.set(downvoted_by.all())
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -184,33 +184,15 @@ def edit_article(request, slug, pk, iframe=False):
         form = EditKBItemForm(request.POST, item.category.slug)
 
         if form.is_valid():
-            category = form.cleaned_data['category']
-            title = form.cleaned_data['title']
-            question = form.cleaned_data['question']
-            answer = form.cleaned_data['answer']
-            order = form.cleaned_data['order']
-            enabled = form.cleaned_data['enabled']
-            voted_by = item.voted_by
-            downvoted_by = item.downvoted_by
+            item.category = form.cleaned_data['category']
+            item.title = form.cleaned_data['title']
+            item.question = form.cleaned_data['question']
+            item.answer = form.cleaned_data['answer']
+            item.order = form.cleaned_data['order']
+            item.enabled = form.cleaned_data['enabled']
 
-            new_item = KBItem(
-                id = item.id,
-                category = category,
-                title = title,
-                question = question,
-                answer = answer,
-                order = order,
-                enabled = enabled,
-                votes = item.votes,
-                recommendations = item.recommendations,
-                team = item.team,
-                last_updated = datetime.datetime.now()
-            )
-            item.delete()
-            new_item.save()
-            new_item.voted_by.set(voted_by.all())
-            new_item.downvoted_by.set(downvoted_by.all())
-        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            item.save()
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[item.category.slug, item.id]))
             
 
 @xframe_options_exempt


### PR DESCRIPTION
Task [#1414](https://clearlyenergy.plan.io/issues/1414):
- Added edit button to the right of the KB article title inside its page.
- Opens full-page form that allows users to edit the properties of the KB article. The following fields are hidden: `voted_by, downvoted_by, votes, recommendations, last_updated, team`
- The `last_updated` field is automatically updated with the datetime at save using `datetime.now()`

**Note**: The code for this pull request was written in a branch based off of `kb_category_edit-itai`, so this pull request includes both the code for KB Category editing and KB Article editing. To my understanding, that means if you merge this pull request before the KB Category pull request, you won't need to merge the KB Category one at all. I don't imagine there would be any merge conflicts if you merged the KB Category pull request first.