### PR TITLE
Queues: View, create, and edit queues within Helpdesk

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -356,8 +356,7 @@ class EditQueueForm(forms.ModelForm):
             Set slug and email address field to read-only.
             Set email address field to "None" if it is empty.
         """
-
-        self.org = kwargs.pop('organization') if kwargs and kwargs['organization'] else None
+        self.org = kwargs.pop('organization', None)
         super(EditQueueForm, self).__init__(*args, **kwargs)
 
         if action == "edit":

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -296,6 +296,56 @@ class EditKBItemForm(forms.ModelForm):
         org = KBCategory.objects.filter(slug=slug).first().organization
         self.fields['category'].queryset = KBCategory.objects.filter(organization=org)
 
+
+class MatchOnField(forms.MultiValueField):
+        
+    def __init__(self, num_widgets, *args, **kwargs):
+        fields = []
+        widgets = []
+        for i in range(0, num_widgets):
+            fields.append(forms.CharField())
+            widgets.append(forms.TextInput())
+        self.widget = MatchOnWidget(widgets=widgets)
+        super(MatchOnField, self).__init__(fields=fields, *args, **kwargs)
+
+    def compress(self, values):
+        return values
+
+class MatchOnWidget(forms.widgets.MultiWidget):
+    #template_name = 'helpdesk/include/multi_text_input.html'
+
+    def decompress(self, value):
+        if value:
+            return value
+        return [None]
+
+
+class EditQueueForm(forms.ModelForm):
+
+    match_on = MatchOnField(num_widgets=2, required=False)
+    slug = forms.SlugField(required=False)
+    email_address = forms.EmailField(required=False)
+
+    class Meta:
+        model = Queue
+        exclude = ('organization','importer')
+
+    def __init__(self, *args, **kwargs):
+        """
+            Set slug and email address field to read-only.
+            TODO: Set email address field to "None" if it is empty.
+        """
+        super(EditQueueForm, self).__init__(*args, **kwargs)
+
+        self.fields['slug'].disabled = True
+        self.fields['email_address'].disabled = True
+
+        #self.fields['match_on'] = MatchOnField()
+
+        #import pdb; pdb.set_trace()        
+
+        
+         
 class AbstractTicketForm(CustomFieldMixin, forms.Form):
     """
     Contain all the common code and fields between "TicketForm" and

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -345,7 +345,7 @@ class EditQueueForm(forms.ModelForm):
             else:
                 return "%s" % user.get_username()
             
-    default_owner = OwnerModelChoiceField(queryset=User.objects)
+    default_owner = OwnerModelChoiceField(queryset=User.objects, required=False)
 
     class Meta:
         model = Queue
@@ -379,11 +379,12 @@ class EditQueueForm(forms.ModelForm):
                 help_text="A list of strings. If you'd like only emails from specific addresses to be imported into this queue, list those addresses here. Otherwise, leave blank.")
 
     def clean(self):
-        cleaned_data = self.cleaned_data
+        cleaned_data = super().clean()
+
 
         # Since organization is an excluded field, validating the unique_together 
         # constraint of slugs must be done manually
-        if Queue.objects.filter(organization=self.org, slug=cleaned_data['slug']).exists():
+        if 'slug' in cleaned_data and Queue.objects.filter(organization=self.org, slug=cleaned_data['slug']).exists():
             raise ValidationError({'slug': ["Queue with this slug already exists in this organization"]})
         
         return cleaned_data

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -273,6 +273,28 @@ class EditKBCategoryForm(forms.ModelForm):
         self.fields['queue'].queryset = Queue.objects.filter(organization=org)
         self.fields['forms'].queryset = FormType.objects.filter(organization=org) 
 
+class EditKBItemForm(forms.ModelForm):
+
+    class CategoryModelChoiceField(forms.ModelChoiceField):
+        def label_from_instance(self, category):
+            return "%s" % (category.name)
+        
+    category = CategoryModelChoiceField(queryset=KBCategory.objects)
+
+    class Meta:
+        model = KBItem
+        exclude = ('voted_by', 'downvoted_by', 'votes', 'recommendations', 'last_updated','team')
+
+    def __init__(self, *args, **kwargs):
+        """
+            Category field will only show category titles.
+            Filter categories by current org.
+        """
+        super(EditKBItemForm, self).__init__(*args, **kwargs)
+
+        slug = kwargs['initial']['category'].slug if kwargs else args[1]
+        org = KBCategory.objects.filter(slug=slug).first().organization
+        self.fields['category'].queryset = KBCategory.objects.filter(organization=org)
 
 class AbstractTicketForm(CustomFieldMixin, forms.Form):
     """

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -291,6 +291,19 @@ class Queue(models.Model):
         self.permission_name = "helpdesk.%s" % basename
         return basename
 
+    @property
+    def get_default_owner(self):
+        """ Custom property to allow us to easily print 'Unassigned' if a
+        ticket has no owner, or the users name if it's assigned. If the user
+        has a full name configured, we use that, otherwise their username. """
+        if not self.default_owner:
+            return _('-')
+        else:
+            if self.default_owner.get_full_name():
+                return self.default_owner.get_full_name()
+            else:
+                return self.default_owner.get_username()
+
     def save(self, *args, **kwargs):
         if not self.id:
             # Prepare the permission codename and the permission

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -15,7 +15,7 @@
     <a href="{% url 'helpdesk:maintain_queues' %}">{% trans "Maintain Queues" %}</a>
 </li>
 <li class="breadcrumb-item active">
-    {% blocktrans with queue.title as qt%} {{ action }}: {{ qt }}{% endblocktrans %}
+    {% blocktrans with queue.title as qt%} {{ action }} {{ qt }}{% endblocktrans %}
 </li>
 {% endblock %}
 

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -24,7 +24,7 @@
         <div class="panel panel-default">
             <div class="panel-body"><h2>{% blocktrans %} {{ action }} Queue {% endblocktrans %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
                 {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
                 <form method='post'>

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -50,6 +50,11 @@
     </div>
 
     <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+
         $("#submit").on('click', function() {
             // Manually aggregate inputted strings for match on fields
             agg_match_on = [];

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -32,7 +32,13 @@
                     <fieldset>
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
-                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <button type='submit' id='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'>
+                                {% if action == "Create" %}
+                                    Create Queue
+                                {% else %}
+                                    Save Changes
+                                {% endif %}
+                            </button>
                             <a href="{% url 'helpdesk:maintain_queues' %}">
                                 <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
@@ -42,5 +48,21 @@
             </div>
         </div>
     </div>
-{% endblock %}
 
+    <script type='text/javascript' language='javascript'>
+        $("#submit").on('click', function() {
+            // Manually aggregate inputted strings for match on fields
+            agg_match_on = [];
+            for (const string of document.getElementById('match_on_strings').children) {
+                agg_match_on.push(string.children[0].value);
+            }  
+            $("[name=agg_match_on]").val(JSON.stringify(agg_match_on));
+        
+            agg_match_on_addresses = [];
+            for (const string of document.getElementById('match_on_addresses_strings').children) {
+                agg_match_on_addresses.push(string.children[0].value);
+            }  
+            $("[name=agg_match_on_addresses]").val(JSON.stringify(agg_match_on_addresses));
+        });
+        </script>    
+{% endblock %}

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -2,7 +2,7 @@
 
 {% load i18n bootstrap4form %}
 
-{% block helpdesk_title %}{% trans "Edit Queue" %}{% endblock %}
+{% block helpdesk_title %}{% blocktrans %} {{ action }} Queue {% endblocktrans %}{% endblock %}
 
 {% block helpdesk_breadcrumb %}
 <li class="breadcrumb-item">
@@ -15,14 +15,14 @@
     <a href="{% url 'helpdesk:maintain_queues' %}">{% trans "Maintain Queues" %}</a>
 </li>
 <li class="breadcrumb-item active">
-    {% blocktrans with queue.title as qt%} Edit: {{ qt }}{% endblocktrans %}
+    {% blocktrans with queue.title as qt%} {{ action }}: {{ qt }}{% endblocktrans %}
 </li>
 {% endblock %}
 
 {% block helpdesk_body %}
     <div class="col-xs-6">
         <div class="panel panel-default">
-            <div class="panel-body"><h2>{% trans "Edit Queue" %}</h2>
+            <div class="panel-body"><h2>{% blocktrans %} {{ action }} Queue {% endblocktrans %}</h2>
                 <p>
                     {% trans "Unless otherwise stated, all fields are required." %}
                 </p>
@@ -34,7 +34,7 @@
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
                             <a href="{% url 'helpdesk:maintain_queues' %}">
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>
@@ -43,3 +43,4 @@
         </div>
     </div>
 {% endblock %}
+

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -1,0 +1,45 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Queue" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:user_settings' %}">{% trans "Settings" %}</a>
+</li>
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:system_settings' %}">{% trans "System Settings" %}</a>
+</li>
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:maintain_queues' %}">{% trans "Maintain Queues" %}</a>
+</li>
+<li class="breadcrumb-item active">
+    {% blocktrans with queue.title as qt%} Edit: {{ qt }}{% endblocktrans %}
+</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Queue" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href="{% url 'helpdesk:maintain_queues' %}">
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/edit_queue.html
+++ b/helpdesk/templates/helpdesk/edit_queue.html
@@ -69,5 +69,11 @@
             }  
             $("[name=agg_match_on_addresses]").val(JSON.stringify(agg_match_on_addresses));
         });
+
+        if (document.getElementById('id_slug').disabled == false) {
+            $('#id_title').on('input', function () {
+                $('#id_slug').val($('#id_title').val().toLowerCase().replaceAll(' ', '-'))
+            })
+        }
         </script>    
 {% endblock %}

--- a/helpdesk/templates/helpdesk/include/multi_text_input.html
+++ b/helpdesk/templates/helpdesk/include/multi_text_input.html
@@ -5,21 +5,18 @@
 </div>
 {% endfor %}
 </div>
-<a href="#">
+<a>
     <button id="{{ widget.name }}_add_string" type="button" class="ml-3 btn btn-outline-secondary">Add String</button>
 </a>
 
 <script type='text/javascript' language='javascript'>
-    let count = Number($("[name=count_{{widget.name}}]").val());
-
     $("#{{ widget.name }}_add_string").on('click', function() {
         // Create new input element and append it to the input container
         new_input_num = document.getElementById("{{widget.name}}_strings").children.length
+        new_elem_type = document.getElementById("{{widget.name}}_strings").children[0].children[0].type
         new_elem = document.createElement('div')
         new_elem.setAttribute('class', 'mb-2 ml-3')
-        new_elem.innerHTML = '<input type="text" name="{{ widget.name }}_0" class=" form-control" id="id_{{ widget.name }}_0" spellcheck="false" data-ms-editor="true">'.replaceAll("{{ widget.name }}_0", "{{ widget.name }}_" + new_input_num);
+        new_elem.innerHTML = '<input type="' + new_elem_type + '" name="{{ widget.name }}_0" class=" form-control" id="id_{{ widget.name }}_0" spellcheck="false" data-ms-editor="true">'.replaceAll("{{ widget.name }}_0", "{{ widget.name }}_" + new_input_num);
         document.getElementById('{{ widget.name }}_strings').appendChild(new_elem);
-
-        $("[name=count_{{widget.name}}]").val(++count);
     });
 </script>

--- a/helpdesk/templates/helpdesk/include/multi_text_input.html
+++ b/helpdesk/templates/helpdesk/include/multi_text_input.html
@@ -1,0 +1,4 @@
+{% include "django/forms/widgets/input.html" %}
+<a href="">
+    <button class="btn btn-primary">Add</button>
+</a>

--- a/helpdesk/templates/helpdesk/include/multi_text_input.html
+++ b/helpdesk/templates/helpdesk/include/multi_text_input.html
@@ -1,4 +1,25 @@
-{% include "django/forms/widgets/input.html" %}
-<a href="">
-    <button class="btn btn-primary">Add</button>
+<div id="{{widget.name}}_strings">
+{% for subwidget in widget.subwidgets %}
+<div class="mb-2 ml-3">
+    {% include "django/forms/widgets/input.html" with widget=subwidget %}
+</div>
+{% endfor %}
+</div>
+<a href="#">
+    <button id="{{ widget.name }}_add_string" type="button" class="ml-3 btn btn-outline-secondary">Add String</button>
 </a>
+
+<script type='text/javascript' language='javascript'>
+    let count = Number($("[name=count_{{widget.name}}]").val());
+
+    $("#{{ widget.name }}_add_string").on('click', function() {
+        // Create new input element and append it to the input container
+        new_input_num = document.getElementById("{{widget.name}}_strings").children.length
+        new_elem = document.createElement('div')
+        new_elem.setAttribute('class', 'mb-2 ml-3')
+        new_elem.innerHTML = '<input type="text" name="{{ widget.name }}_0" class=" form-control" id="id_{{ widget.name }}_0" spellcheck="false" data-ms-editor="true">'.replaceAll("{{ widget.name }}_0", "{{ widget.name }}_" + new_input_num);
+        document.getElementById('{{ widget.name }}_strings').appendChild(new_elem);
+
+        $("[name=count_{{widget.name}}]").val(++count);
+    });
+</script>

--- a/helpdesk/templates/helpdesk/include/multi_text_input.html
+++ b/helpdesk/templates/helpdesk/include/multi_text_input.html
@@ -6,7 +6,7 @@
 {% endfor %}
 </div>
 <a>
-    <button id="{{ widget.name }}_add_string" type="button" class="ml-3 btn btn-outline-secondary">Add String</button>
+    <button id="{{ widget.name }}_add_string" type="button" class="ml-3 btn btn-outline-secondary">Add Field</button>
 </a>
 
 <script type='text/javascript' language='javascript'>

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -1,8 +1,15 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
 <div class="row" style="display:inline">
-    <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
-    <a style="vertial-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
+    <div class="d-flex">
+        <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
+        <div class="flex-fill d-flex justify-content-end">
+            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
+                <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+            </a>
+        </div>
+    </div>
+    <a style="vertical-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
         <i class="fa fa-angle-double-left"></i> Previous Item
     </a>
     <a class="btn btn-secondary btn-sm{% if not next_item %} disabled{% endif %}" href="{{ next_item.get_absolute_url }}/{{ user_info.url }}">

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -1,0 +1,40 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">
+    <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} Edit: {{ itemq }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -1,6 +1,16 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
-<h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+<div class="d-flex">
+    <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+    {% if user|is_helpdesk_staff %}
+    <div class="flex-fill d-flex justify-content-end">
+        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        </a>
+    </div>
+    {% endif %}
+</div>
+
 {% endblock %}
 
 <div class="container-fluid">

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -1,0 +1,37 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/queue_list.html
+++ b/helpdesk/templates/helpdesk/queue_list.html
@@ -1,5 +1,7 @@
 {% extends "helpdesk/base.html" %}{% load i18n humanize %}
 
+{% block helpdesk_title %}{% blocktrans %} Maintain Queues {% endblocktrans %}{% endblock %}
+
 {% block helpdesk_breadcrumb %}
 <li class="breadcrumb-item">
     <a href="{% url 'helpdesk:user_settings' %}">{% trans "Settings" %}</a>
@@ -24,21 +26,22 @@
         </div>
     </div>
     <div class="card-body">
-        {# <p> Select a queue title to edit the queue. </p> #}
+        {% comment %} <p class="my-1"> Select a queue title to edit the queue. </p> {% endcomment %}
         <div class="table-responsive">
         <table class="table table-bordered table-sm table-striped" id="dataTable" width="100%" cellspacing="0">
             <thead class="thead-light">
                 <tr>
                     {# Need to decide which columns are most relevant to the user #}
-                    <th>{% trans "Organization" %}</th>
+                    {% comment %} <th>{% trans "Organization" %}</th> {% endcomment %}
                     <th>{% trans "Title" %}</th>
                     <th>{% trans "Slug" %}</th> {# May not need to be a column #}
-                    <th>{% trans "Importer" %}</th> {# May not need to be a column #}
+                    {% comment %} <th>{% trans "Importer" %}</th> {# May not need to be a column #} {% endcomment %}
                     <th>{% trans "Public Submission" %}</th>
                     <th>{% trans "Notify on Email" %}</th>
                     <th>{% trans "Reassign on Close" %}</th>
-                    <th>{% trans "Escalation Days" %}</th> {# May not need to be a column #}
-                    <th>{% trans "Dedicated Time" %}</th> {# May not need to be a column #}
+                    <th>{% trans "Default Owner" %}</th>
+                    {% comment %} <th>{% trans "Escalation Days" %}</th> {# May not need to be a column #} {% endcomment %}
+                    {% comment %} <th>{% trans "Dedicated Time" %}</th> {# May not need to be a column #} {% endcomment %}
                     <th>{% trans "Match On" %}</th> {# May not need to be a column #}
                     <th>{% trans "Match On Addresses" %}</th> {# May not need to be a column #}
                 </tr>
@@ -46,10 +49,10 @@
             <tbody>
                 {% for queue in queue_list %}
                 <tr>
-                    <td>{{ queue.organization.name }}</td>
+                    {% comment %} <td>{{ queue.organization.name }}</td> {% endcomment %}
                     <td class="tickettitle" data-toggle="tooltip" title="Edit {{ queue.title }}"><a href="{% url 'helpdesk:edit_queue' queue.slug %}{{ user_info.url }}">{{ queue.id }}. {{ queue.title }}</a></td>
                     <td>{{ queue.slug }}</td>
-                    <td>{% if queue.importer %}{{queue.importer}}{% else%}-{% endif %}</td>
+                    {% comment %} <td>{% if queue.importer %}{{queue.importer}}{% else%}-{% endif %}</td> {% endcomment %}
                     <td>
                         {# This block could be another template, since it is reused 3 times in this code #}
                         {% if queue.allow_public_submission %}
@@ -72,51 +75,54 @@
                             <i class="fa fa-times-circle text-danger">
                         {% endif%}
                     </td>
-                    <td>{% if queue.importer %}{{queue.escalate_days}}{% else%}-{% endif %}</td>
-                    <td>{% if queue.importer %}{{queue.dedicated_time}}{% else%}-{% endif %}</td>
+                    <td>{% if queue.get_default_owner %}{{queue.get_default_owner}}{% else%}-{% endif %}</td>
+                    {% comment %} <td>{% if queue.escalate_days %}{{queue.escalate_days}}{% else%}-{% endif %}</td> {% endcomment %}
+                    {% comment %} <td>{% if queue.dedicated_time %}{{queue.dedicated_time}}{% else%}-{% endif %}</td> {% endcomment %}
                     <td>{{queue.match_on}}</td>
                     <td>{{queue.match_on_addresses}}</td>
                 </tr>
 
                 {% empty %}
-                <tr>{% if ticket_list_empty_message %}<td colspan='6'>{{ ticket_list_empty_message }}</td>{% else %}<td colspan='6'>{% trans "You do not have any queues." %}</td>{% endif %}</tr>
+                <tr><td colspan='6'>{% trans "You do not have any queues." %}</td></tr>
                 {% endfor %}
             </tbody>
         </table>
         </div>
         <!-- /.table-responsive -->
+        {% with 'q_page' as page_var %}
         {% if queue_list.has_other_pages %}
             <ul class="pagination">
             <!-- if we aren't on page one, go back to start and go back one controls -->
-            {% if ticket_list.has_previous %}
+            {% if queue_list.has_previous %}
                 <li><a href="?{{ page_var }}=1">&laquo;&laquo;</a>&nbsp;</li>
-                <li><a href="?{{ page_var }}={{ ticket_list.previous_page_number }}">&laquo;</a>&nbsp;</li>
+                <li><a href="?{{ page_var }}={{ queue_list.previous_page_number }}">&laquo;</a>&nbsp;</li>
             {% else %}
                 <li class="disabled"><span>&laquo;&laquo;&nbsp;</span></li>
                 <li class="disabled"><span>&laquo;&nbsp;</span></li>
             {% endif %}
             <!-- other pages, set thresh to the number to show before and after active -->
             {% with 5 as thresh %}
-            {% for i in ticket_list.paginator.page_range %}
-            {% if ticket_list.number == i %}
+            {% for i in queue_list.paginator.page_range %}
+            {% if queue_list.number == i %}
                 <li class="active"><span>{{ i }}&nbsp;<span class="sr-only">(current)</span></span></li>
-            {% elif i <= ticket_list.number|add:5 and i >= ticket_list.number|add:-5 %}
+            {% elif i <= queue_list.number|add:5 and i >= queue_list.number|add:-5 %}
                 <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a>&nbsp;</li>
             {% endif %}
             {% endfor %}
             {% endwith %}
             <!-- if we aren't on the last page, go forward one and go to end controls -->
-            {% if ticket_list.has_next %}
-                <li><a href="?{{ page_var }}={{ ticket_list.next_page_number }}">&raquo;</a>&nbsp;</li>
-                <li><a href="?{{ page_var }}={{ ticket_list.paginator.num_pages }}">&raquo;&raquo;</a>&nbsp;</li>
+            {% if queue_list.has_next %}
+                <li><a href="?{{ page_var }}={{ queue_list.next_page_number }}">&raquo;</a>&nbsp;</li>
+                <li><a href="?{{ page_var }}={{ queue_list.paginator.num_pages }}">&raquo;&raquo;</a>&nbsp;</li>
             {% else %}
                 <li class="disabled"><span>&raquo;&nbsp;</span></li>
                 <li class="disabled"><span>&raquo;&raquo;&nbsp;</span></li>
             {% endif %}
             </ul>
         {% endif %}
+        {% endwith %}
     </div>
-    <div class="card-footer small text-muted">Listing {{ ticket_list|length }} ticket(s) out of {{ ticket_list.paginator.count }}.</div>
+    <div class="card-footer small text-muted">Listing {{ queue_list|length }} queue(s) out of {{ queue_list.paginator.count }}.</div>
 </div>
 
 {% endblock %}

--- a/helpdesk/templates/helpdesk/queue_list.html
+++ b/helpdesk/templates/helpdesk/queue_list.html
@@ -18,7 +18,7 @@
         <i class="fas fa-table mr-1"></i>
         {% trans "Maintain Queues" %}
         <div class="flex-fill d-flex justify-content-end">
-            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:maintain_queues' %}{{ user_info.url }}">
+            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:create_queue' %}{{ user_info.url }}">
                 <i class="fa fa-plus mr-1"></i>Create
             </a>
         </div>

--- a/helpdesk/templates/helpdesk/queue_list.html
+++ b/helpdesk/templates/helpdesk/queue_list.html
@@ -1,0 +1,124 @@
+{% extends "helpdesk/base.html" %}{% load i18n humanize %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:user_settings' %}">{% trans "Settings" %}</a>
+</li>
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:system_settings' %}">{% trans "System Settings" %}</a>
+</li>
+<li class="breadcrumb-item active">
+    Maintain Queues
+</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+<div class="card mb-3">
+    <div class="card-header d-flex align-items-center">
+        <i class="fas fa-table mr-1"></i>
+        {% trans "Maintain Queues" %}
+        <div class="flex-fill d-flex justify-content-end">
+            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:maintain_queues' %}{{ user_info.url }}">
+                <i class="fa fa-plus mr-1"></i>Create
+            </a>
+        </div>
+    </div>
+    <div class="card-body">
+        {# <p> Select a queue title to edit the queue. </p> #}
+        <div class="table-responsive">
+        <table class="table table-bordered table-sm table-striped" id="dataTable" width="100%" cellspacing="0">
+            <thead class="thead-light">
+                <tr>
+                    {# Need to decide which columns are most relevant to the user #}
+                    <th>{% trans "Organization" %}</th>
+                    <th>{% trans "Title" %}</th>
+                    <th>{% trans "Slug" %}</th> {# May not need to be a column #}
+                    <th>{% trans "Importer" %}</th> {# May not need to be a column #}
+                    <th>{% trans "Public Submission" %}</th>
+                    <th>{% trans "Notify on Email" %}</th>
+                    <th>{% trans "Reassign on Close" %}</th>
+                    <th>{% trans "Escalation Days" %}</th> {# May not need to be a column #}
+                    <th>{% trans "Dedicated Time" %}</th> {# May not need to be a column #}
+                    <th>{% trans "Match On" %}</th> {# May not need to be a column #}
+                    <th>{% trans "Match On Addresses" %}</th> {# May not need to be a column #}
+                </tr>
+            </thead>
+            <tbody>
+                {% for queue in queue_list %}
+                <tr>
+                    <td>{{ queue.organization.name }}</td>
+                    <td class="tickettitle" data-toggle="tooltip" title="Edit {{ queue.title }}"><a href="{% url 'helpdesk:edit_queue' queue.slug %}{{ user_info.url }}">{{ queue.id }}. {{ queue.title }}</a></td>
+                    <td>{{ queue.slug }}</td>
+                    <td>{% if queue.importer %}{{queue.importer}}{% else%}-{% endif %}</td>
+                    <td>
+                        {# This block could be another template, since it is reused 3 times in this code #}
+                        {% if queue.allow_public_submission %}
+                            <i class="fa fa-check-circle text-success">
+                        {% else %}
+                            <i class="fa fa-times-circle text-danger">
+                        {% endif%}
+                    </td>
+                    <td>
+                        {% if queue.enable_notifications_on_email_events %}
+                            <i class="fa fa-check-circle text-success">
+                        {% else %}
+                            <i class="fa fa-times-circle text-danger">
+                        {% endif%}
+                    </td>
+                    <td>
+                        {% if queue.reassign_when_closed %}
+                            <i class="fa fa-check-circle text-success">
+                        {% else %}
+                            <i class="fa fa-times-circle text-danger">
+                        {% endif%}
+                    </td>
+                    <td>{% if queue.importer %}{{queue.escalate_days}}{% else%}-{% endif %}</td>
+                    <td>{% if queue.importer %}{{queue.dedicated_time}}{% else%}-{% endif %}</td>
+                    <td>{{queue.match_on}}</td>
+                    <td>{{queue.match_on_addresses}}</td>
+                </tr>
+
+                {% empty %}
+                <tr>{% if ticket_list_empty_message %}<td colspan='6'>{{ ticket_list_empty_message }}</td>{% else %}<td colspan='6'>{% trans "You do not have any queues." %}</td>{% endif %}</tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+        <!-- /.table-responsive -->
+        {% if queue_list.has_other_pages %}
+            <ul class="pagination">
+            <!-- if we aren't on page one, go back to start and go back one controls -->
+            {% if ticket_list.has_previous %}
+                <li><a href="?{{ page_var }}=1">&laquo;&laquo;</a>&nbsp;</li>
+                <li><a href="?{{ page_var }}={{ ticket_list.previous_page_number }}">&laquo;</a>&nbsp;</li>
+            {% else %}
+                <li class="disabled"><span>&laquo;&laquo;&nbsp;</span></li>
+                <li class="disabled"><span>&laquo;&nbsp;</span></li>
+            {% endif %}
+            <!-- other pages, set thresh to the number to show before and after active -->
+            {% with 5 as thresh %}
+            {% for i in ticket_list.paginator.page_range %}
+            {% if ticket_list.number == i %}
+                <li class="active"><span>{{ i }}&nbsp;<span class="sr-only">(current)</span></span></li>
+            {% elif i <= ticket_list.number|add:5 and i >= ticket_list.number|add:-5 %}
+                <li><a href="?{{ page_var }}={{ i }}">{{ i }}</a>&nbsp;</li>
+            {% endif %}
+            {% endfor %}
+            {% endwith %}
+            <!-- if we aren't on the last page, go forward one and go to end controls -->
+            {% if ticket_list.has_next %}
+                <li><a href="?{{ page_var }}={{ ticket_list.next_page_number }}">&raquo;</a>&nbsp;</li>
+                <li><a href="?{{ page_var }}={{ ticket_list.paginator.num_pages }}">&raquo;&raquo;</a>&nbsp;</li>
+            {% else %}
+                <li class="disabled"><span>&raquo;&nbsp;</span></li>
+                <li class="disabled"><span>&raquo;&raquo;&nbsp;</span></li>
+            {% endif %}
+            </ul>
+        {% endif %}
+    </div>
+    <div class="card-footer small text-muted">Listing {{ ticket_list|length }} ticket(s) out of {{ ticket_list.paginator.count }}.</div>
+</div>
+
+{% endblock %}
+
+

--- a/helpdesk/templates/helpdesk/system_settings.html
+++ b/helpdesk/templates/helpdesk/system_settings.html
@@ -17,13 +17,13 @@
 <p>{% blocktrans %}The following items can be maintained by you or other superusers:{% endblocktrans %}</p>
 
 <ul>
-    <li><a href='{% url 'helpdesk:email_ignore' %}'>{% trans "E-Mail Ignore list" %}</a></li>
-    <!-- <li><a href='{% url 'admin:helpdesk_queue_changelist' %}'>{% trans "Maintain Queues" %}</a></li> -->
+    {% comment %} <li><a href='{% url 'helpdesk:email_ignore' %}'>{% trans "E-Mail Ignore list" %}</a></li> {% endcomment %}
+    {% comment %} <li><a href='{% url 'admin:helpdesk_queue_changelist' %}'>{% trans "Maintain Queues" %}</a></li> {% endcomment %}
     <li><a href='{% url 'helpdesk:maintain_queues' %}'>{% trans "Maintain Queues" %}</a></li>
-    <li><a href='{% url 'admin:helpdesk_presetreply_changelist' %}'>{% trans "Maintain Pre-Set Replies" %}</a></li>
-    <li><a href='{% url 'admin:helpdesk_kbcategory_changelist' %}'>{% trans "Maintain Knowledgebase Categories" %}</a></li>
-    <li><a href='{% url 'admin:helpdesk_kbitem_changelist' %}'>{% trans "Maintain Knowledgebase Items" %}</a></li>
-    <li><a href='{% url 'admin:helpdesk_emailtemplate_changelist' %}'>{% trans "Maintain E-Mail Templates" %}</a></li>
+    {% comment %} <li><a href='{% url 'admin:helpdesk_presetreply_changelist' %}'>{% trans "Maintain Pre-Set Replies" %}</a></li> {% endcomment %}
+    {% comment %} <li><a href='{% url 'admin:helpdesk_kbcategory_changelist' %}'>{% trans "Maintain Knowledgebase Categories" %}</a></li> {% endcomment %}
+    {% comment %} <li><a href='{% url 'admin:helpdesk_kbitem_changelist' %}'>{% trans "Maintain Knowledgebase Items" %}</a></li> {% endcomment %}
+    {% comment %} <li><a href='{% url 'admin:helpdesk_emailtemplate_changelist' %}'>{% trans "Maintain E-Mail Templates" %}</a></li> {% endcomment %}
     <!--<li><a href='{# url 'changelist'|user_admin_url #}'>{% trans "Maintain Users" %}</a></li>-->
     <!-- TODO above does not work with SEED yet -->
 </ul>

--- a/helpdesk/templates/helpdesk/system_settings.html
+++ b/helpdesk/templates/helpdesk/system_settings.html
@@ -18,7 +18,8 @@
 
 <ul>
     <li><a href='{% url 'helpdesk:email_ignore' %}'>{% trans "E-Mail Ignore list" %}</a></li>
-    <li><a href='{% url 'admin:helpdesk_queue_changelist' %}'>{% trans "Maintain Queues" %}</a></li>
+    <!-- <li><a href='{% url 'admin:helpdesk_queue_changelist' %}'>{% trans "Maintain Queues" %}</a></li> -->
+    <li><a href='{% url 'helpdesk:maintain_queues' %}'>{% trans "Maintain Queues" %}</a></li>
     <li><a href='{% url 'admin:helpdesk_presetreply_changelist' %}'>{% trans "Maintain Pre-Set Replies" %}</a></li>
     <li><a href='{% url 'admin:helpdesk_kbcategory_changelist' %}'>{% trans "Maintain Knowledgebase Categories" %}</a></li>
     <li><a href='{% url 'admin:helpdesk_kbitem_changelist' %}'>{% trans "Maintain Knowledgebase Items" %}</a></li>

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -324,4 +324,16 @@ urlpatterns += [
     url(r'^system_settings/$',
         login_required(DirectTemplateView.as_view(template_name='helpdesk/system_settings.html')),
         name='system_settings'),
+    
+    url(r'^system_settings/maintain_queues/$',
+        staff.queue_list,
+        name='maintain_queues'),
+
+    url(r'^system_settings/maintain_queues/create/$',
+        staff.create_queue,
+        name='create_queue'),
+
+    url(r'^system_settings/maintain_queues/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
+        staff.edit_queue,
+        name='edit_queue')
 ]

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -293,6 +293,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.category,
             name='kb_category'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
+            kb.edit_category,
+            name="edit_kb_category"),
+
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,
             name='kb_vote'),

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -289,6 +289,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.article,
             name='kb_article'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/edit/$',
+            kb.edit_article,
+            name="edit_kb_article"),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -158,6 +158,11 @@ def article(request, slug, pk, iframe=False):
         'kb_forms': kb_forms
     })
 
+@helpdesk_staff_member_required
+def edit_article(request, slug, pk, iframe=False):
+
+    # Stub return
+    return
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -18,8 +18,10 @@ from helpdesk import settings as helpdesk_settings
 from helpdesk import user
 from helpdesk.models import KBCategory, KBItem
 from helpdesk.decorators import is_helpdesk_staff, helpdesk_staff_member_required
-from helpdesk.forms import EditKBCategoryForm
+from helpdesk.forms import EditKBCategoryForm, EditKBItemForm
 from django.utils.html import escape
+
+import datetime
 
 def index(request):
     huser = user.huser_from_request(request)
@@ -160,9 +162,56 @@ def article(request, slug, pk, iframe=False):
 
 @helpdesk_staff_member_required
 def edit_article(request, slug, pk, iframe=False):
+    item = get_object_or_404(KBItem, pk=pk)
 
-    # Stub return
-    return
+    if request.method == "GET":
+        form = EditKBItemForm(initial={
+            'category': item.category,
+            'title': item.title,
+            'question': item.question,
+            'answer': item.answer,
+            'order': item.order,
+            'enabled': item.enabled,
+        })
+
+        return render(request, 'helpdesk/kb_article_edit.html', {
+            'category': item.category,
+            'item': item,
+            'form': form,
+            'debug': settings.DEBUG,
+        })
+    elif request.method == "POST":
+        form = EditKBItemForm(request.POST, item.category.slug)
+
+        if form.is_valid():
+            category = form.cleaned_data['category']
+            title = form.cleaned_data['title']
+            question = form.cleaned_data['question']
+            answer = form.cleaned_data['answer']
+            order = form.cleaned_data['order']
+            enabled = form.cleaned_data['enabled']
+            voted_by = item.voted_by
+            downvoted_by = item.downvoted_by
+
+            new_item = KBItem(
+                id = item.id,
+                category = category,
+                title = title,
+                question = question,
+                answer = answer,
+                order = order,
+                enabled = enabled,
+                votes = item.votes,
+                recommendations = item.recommendations,
+                team = item.team,
+                last_updated = datetime.datetime.now()
+            )
+            item.delete()
+            new_item.save()
+            new_item.voted_by.set(voted_by.all())
+            new_item.downvoted_by.set(downvoted_by.all())
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -178,7 +178,7 @@ def create_queue(request):
                 title = form.cleaned_data['title'],
                 slug = form.cleaned_data['slug'], # no change
                 match_on = [i for i in form.cleaned_data['agg_match_on'] if i], # remove empty strings
-                match_on_addresses = [i for i in form.cleaned_data['agg_match_on_addresses'] if i],
+                match_on_addresses = [i for i in form.cleaned_data['agg_match_on_addresses'] if i], # remove empty strings
                 allow_public_submission = form.cleaned_data['allow_public_submission'],
                 escalate_days = form.cleaned_data['escalate_days'],
                 enable_notifications_on_email_events = form.cleaned_data['enable_notifications_on_email_events'],
@@ -197,7 +197,7 @@ def create_queue(request):
                 'title': form.cleaned_data['title'],
                 'slug': form.data['slug'], # no change
                 'match_on': [i for i in form.cleaned_data['agg_match_on'] if i], # remove empty strings
-                'match_on_addresses': [i for i in form.cleaned_data['agg_match_on_addresses'] if i],
+                'match_on_addresses': [i for i in form.cleaned_data['agg_match_on_addresses'] if i], # remove empty strings
                 'allow_public_submission': form.cleaned_data['allow_public_submission'],
                 'escalate_days': form.cleaned_data['escalate_days'],
                 'enable_notifications_on_email_events': form.cleaned_data['enable_notifications_on_email_events'],
@@ -222,6 +222,7 @@ def edit_queue(request, slug):
     if request.method == "GET":
         form = EditQueueForm(
             "edit",
+            organization=request.user.default_organization.id,
             initial = {
                 'organization': queue.organization.id,
                 'title': queue.title,
@@ -237,8 +238,7 @@ def edit_queue(request, slug):
                 'reassign_when_closed': queue.reassign_when_closed,
                 'dedicated_time': queue.dedicated_time,
                 'email_address': queue.email_address if queue.email_address else "None",
-            },
-            organization=request.user.default_organization.id   
+            }
         )
 
         return render(request, 'helpdesk/edit_queue.html', {
@@ -250,11 +250,10 @@ def edit_queue(request, slug):
     elif request.method == "POST":
         form = EditQueueForm("edit", request.POST, organization=request.user.default_organization.id)
         if form.is_valid():
-            
             queue.title = form.cleaned_data['title']
             # queue.slug = form.cleaned_data['slug'] # no change
             queue.match_on = [i for i in form.cleaned_data['agg_match_on'] if i] # remove empty strings
-            queue.match_on_addresses = [i for i in form.cleaned_data['agg_match_on_addresses'] if i]
+            queue.match_on_addresses = [i for i in form.cleaned_data['agg_match_on_addresses'] if i] # remove empty strings
             queue.allow_public_submission = form.cleaned_data['allow_public_submission']
             queue.escalate_days = form.cleaned_data['escalate_days']
             queue.enable_notifications_on_email_events = form.cleaned_data['enable_notifications_on_email_events']

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -145,8 +145,49 @@ def queue_list(request):
 
 @helpdesk_staff_member_required
 def create_queue(request):
-    # Stub return
-    return
+    if request.method == "GET":
+        form = EditQueueForm(
+            # initial = {
+            #     'title': "",
+            #     'slug': "",
+            #     'match_on': [""],
+            #     'count_match_on': 1,
+            #     'match_on_addresses': [""],
+            #     'count_match_on_addresses': 1,
+            #     'allow_public_submission': False,
+            #     'escalate_days': 0,
+            #     'enable_notifications_on_email_events': False,
+            #     'default_owner': "",
+            #     'reassign_when_closed': False,
+            #     'dedicated_time': 0,
+            #     'email_address': "",
+            # }
+        )
+
+        return render(request, 'helpdesk/edit_queue.html', {
+            'form': EditQueueForm(),
+            'action': "Create",
+            'debug': settings.DEBUG,
+        })
+    elif request.method == "POST":
+        form = EditQueueForm(request.POST, request.POST.get('count_match_on'), request.POST.get('count_match_on_addresses'))
+
+        if form.is_valid():
+            #import pdb; pdb.set_trace()
+            queue = Queue(
+                title = form.cleaned_data['title'],
+                slug = form.cleaned_data['slug'], # no change
+                match_on = [i for i in form.cleaned_data['match_on'] if i], # remove empty strings
+                match_on_addresses = form.cleaned_data['match_on_addresses'],
+                allow_public_submission = form.cleaned_data['allow_public_submission'],
+                escalate_days = form.cleaned_data['escalate_days'],
+                enable_notifications_on_email_events = form.cleaned_data['enable_notifications_on_email_events'],
+                default_owner = form.cleaned_data['default_owner'],
+                reassign_when_closed = form.cleaned_data['reassign_when_closed'],
+                dedicated_time = form.cleaned_data['dedicated_time'],
+            )
+            queue.save()
+        return HttpResponseRedirect(reverse('helpdesk:maintain_queues')) 
 
 @helpdesk_staff_member_required
 def edit_queue(request, slug):
@@ -154,11 +195,13 @@ def edit_queue(request, slug):
     queue = get_object_or_404(Queue, slug=slug)
 
     if request.method == "GET":
-        form = EditQueueForm(initial={
+        form = EditQueueForm(initial = {
             'title': queue.title,
             'slug': queue.slug,
             'match_on': queue.match_on,
+            'count_match_on': len(queue.match_on) + 1,
             'match_on_addresses': queue.match_on_addresses,
+            'count_match_on_addresses': len(queue.match_on_addresses) + 1,
             'allow_public_submission': queue.allow_public_submission,
             'escalate_days': queue.escalate_days,
             'enable_notifications_on_email_events': queue.enable_notifications_on_email_events,
@@ -171,44 +214,26 @@ def edit_queue(request, slug):
         return render(request, 'helpdesk/edit_queue.html', {
             'queue': queue,
             'form': form,
+            'action': "Edit",
             'debug': settings.DEBUG,
         })
     elif request.method == "POST":
-        form = EditQueueForm(request.POST)
+        form = EditQueueForm(request.POST, request.POST.get('count_match_on'), request.POST.get('count_match_on_addresses'))
 
         if form.is_valid():
-            #import pdb; pdb.set_trace()
-            title = form.cleaned_data['title']
-            # slug = form.cleaned_data['slug']
-            match_on = form.cleaned_data['match_on']
-            match_on_addresses = form.cleaned_data['match_on_addresses']
-            allow_public_submission = form.cleaned_data['allow_public_submission']
-            escalate_days = form.cleaned_data['escalate_days']
-            enable_notifications_on_email_events = form.cleaned_data['enable_notifications_on_email_events']
-            default_owner = form.cleaned_data['default_owner']
-            reassign_when_closed = form.cleaned_data['reassign_when_closed']
-            dedicated_time = form.cleaned_data['dedicated_time']
-            # email_address = form.cleaned_data['email_address']
-            #ticket_set = queue.ticket_set()
-
-            new_queue = Queue(
-                id = queue.id,
-                organization = queue.organization,
-                importer = queue.importer,
-                title = title,
-                slug = queue.slug,
-                match_on = match_on,
-                match_on_addresses = match_on_addresses,
-                allow_public_submission = allow_public_submission,
-                escalate_days = escalate_days,
-                enable_notifications_on_email_events = enable_notifications_on_email_events,
-                default_owner = default_owner,
-                reassign_when_closed = reassign_when_closed,
-                dedicated_time = dedicated_time,
-            )
-            queue.delete()
-            new_queue.save()
-            #new_queue.ticket_set.set()
+            # import pdb; pdb.set_trace()
+            queue.title = form.cleaned_data['title']
+            # queue.slug = form.cleaned_data['slug'] # no change
+            queue.match_on = [i for i in form.cleaned_data['match_on'] if i] # remove empty strings
+            queue.match_on_addresses = form.cleaned_data['match_on_addresses']
+            queue.allow_public_submission = form.cleaned_data['allow_public_submission']
+            queue.escalate_days = form.cleaned_data['escalate_days']
+            queue.enable_notifications_on_email_events = form.cleaned_data['enable_notifications_on_email_events']
+            queue.default_owner = form.cleaned_data['default_owner']
+            queue.reassign_when_closed = form.cleaned_data['reassign_when_closed']
+            queue.dedicated_time = form.cleaned_data['dedicated_time']
+            
+            queue.save()
         return HttpResponseRedirect(reverse('helpdesk:maintain_queues')) 
 
 


### PR DESCRIPTION
Task [#1415](https://clearlyenergy.plan.io/issues/1415):
- Removed all links from system settings besides "Maintain Queues"
- "Maintain Queues" link now points to a new page with a table of the organization's queues instead of the Django admin page.
- Users can create a new queue from the "Maintain queues" page using the create button in the table header, or edit an existing queue by clicking on its title within the table.
- During queues creation or editing, it is now more streamlined to add match on subjects or email addresses through the use of a MultiValueField in which each subject/email is its own text input (with appropriate validation). The user can add more using an "add field" button on the form. This uses a client-side JavaScript implementation rather than a server-side Django implementation to dynamically generate new fields and aggregate their data.
  - See `templates/helpdesk/include/multi_text_input.html` for JavaScript implementation details on how new fields are dynamically generated
  - See `templates/helpdesk/queue_edit.html` for JavaScript implementation details on how field data is aggregated for use by Django.
- During queue creation, if the user attempts to create a queue with a slug that already exists, the form reloads with an error message indicating the slug already exists within their organization. All previously entered form data will transfer to the new form after reload.