### PR TITLE
Knowledgebase: create and delete categories and articles in Helpdesk

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -273,6 +273,28 @@ class EditKBCategoryForm(forms.ModelForm):
         self.fields['queue'].queryset = Queue.objects.filter(organization=org)
         self.fields['forms'].queryset = FormType.objects.filter(organization=org) 
 
+class EditKBItemForm(forms.ModelForm):
+
+    class CategoryModelChoiceField(forms.ModelChoiceField):
+        def label_from_instance(self, category):
+            return "%s" % (category.name)
+        
+    category = CategoryModelChoiceField(queryset=KBCategory.objects)
+
+    class Meta:
+        model = KBItem
+        exclude = ('voted_by', 'downvoted_by', 'votes', 'recommendations', 'last_updated','team')
+
+    def __init__(self, *args, **kwargs):
+        """
+            Category field will only show category titles.
+            Filter categories by current org.
+        """
+        super(EditKBItemForm, self).__init__(*args, **kwargs)
+
+        slug = kwargs['initial']['category'].slug if kwargs else args[1]
+        org = KBCategory.objects.filter(slug=slug).first().organization
+        self.fields['category'].queryset = KBCategory.objects.filter(organization=org)
 
 class AbstractTicketForm(CustomFieldMixin, forms.Form):
     """

--- a/helpdesk/templates/helpdesk/include/confirm_delete.html
+++ b/helpdesk/templates/helpdesk/include/confirm_delete.html
@@ -1,0 +1,25 @@
+<div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm {{ type }} Deletion</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Please confirm that you want to delete the {{ type }}: <strong>{{ title }}</strong>. 
+                    </br> </br>
+                    This action <strong>cannot</strong> be undone.
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <a href="{{ delete_url }}">
+                    <button type="button"  class="btn btn-danger">Delete {{ type }}</button>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -18,6 +18,7 @@
     <a class="btn btn-secondary btn-sm{% if not next_item %} disabled{% endif %}" href="{{ next_item.get_absolute_url }}/{{ user_info.url }}">
         Next Item <i class="fa fa-angle-double-right"></i>
     </a>
+    (Last Updated: {{item.last_updated}})
 </div>
 {% endblock %}
 

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -1,8 +1,15 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
 <div class="row" style="display:inline">
-    <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
-    <a style="vertial-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
+    <div class="d-flex">
+        <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
+        <div class="flex-fill d-flex justify-content-end">
+            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
+                <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+            </a>
+        </div>
+    </div>
+    <a style="vertical-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
         <i class="fa fa-angle-double-left"></i> Previous Item
     </a>
     <a class="btn btn-secondary btn-sm{% if not next_item %} disabled{% endif %}" href="{{ next_item.get_absolute_url }}/{{ user_info.url }}">

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -4,8 +4,11 @@
     <div class="d-flex">
         <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
         <div class="flex-fill d-flex justify-content-end">
-            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
-                <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+            <a class="btn btn-primary align-self-center mr-2" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
+                <i class="fa fa-pen mr-1"></i>Edit Article
+            </a>
+            <a class="btn btn-danger align-self-center" data-toggle="modal" data-target="#deleteModal">
+                <i class="fa fa-trash mr-1"></i>Delete Article
             </a>
         </div>
     </div>
@@ -43,3 +46,6 @@
 </div>
 {% block footer %}
 {% endblock %}
+
+{% url 'helpdesk:delete_kb_article' category.slug item.id as delete_url%}
+{% include 'helpdesk/include/confirm_delete.html' with type="Article" title=item.title delete_url=delete_url %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -1,0 +1,40 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">
+    <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} Edit: {{ itemq }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -19,7 +19,7 @@
         <div class="panel panel-default">
             <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
                 {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
                 <form method='post'>
@@ -37,4 +37,11 @@
             </div>
         </div>
     </div>
+
+    <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+    </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -28,8 +28,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -2,7 +2,7 @@
 
 {% load i18n bootstrap4form %}
 
-{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+{% block helpdesk_title %}{% blocktrans %}{{ action }} Article{% endblocktrans %}{% endblock %}
 
 {% block helpdesk_breadcrumb %}
 <li class="breadcrumb-item">
@@ -11,13 +11,13 @@
 <li class="breadcrumb-item active">
     <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</a>
 </li>
-<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} Edit: {{ itemq }}{% endblocktrans %}</li>
+<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} {{ action }} {{ itemq }}{% endblocktrans %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}
     <div class="col-xs-6">
         <div class="panel panel-default">
-            <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
+            <div class="panel-body"><h2>{% blocktrans %} {{ action }} Article {% endblocktrans %}</h2>
                 <p>
                     {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
@@ -27,9 +27,16 @@
                     <fieldset>
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
-                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href="{% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}">
-                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <input type='submit' class="btn btn-primary btn" 
+                                value="{% if action == "Create"%}Create Article{% else %}Save Changes{% endif %}"/>
+                            <a href="
+                            {% if action == "Create"%}
+                                {% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}
+                            {% else %}
+                                {% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}
+                            {% endif %}
+                            ">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -4,8 +4,14 @@
     <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
     {% if user|is_helpdesk_staff %}
     <div class="flex-fill d-flex justify-content-end">
-        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
-            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        <a class="btn btn-primary align-self-center mr-2" href="{% url 'helpdesk:create_kb_article' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-plus mr-1"></i>Create Article
+        </a>
+        <a class="btn btn-primary align-self-center mr-2" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen mr-1" ></i>Edit Category
+        </a>
+        <a class="btn btn-danger align-self-center" data-toggle="modal" data-target="#deleteModal">
+            <i class="fa fa-trash mr-1"></i>Delete Category
         </a>
     </div>
     {% endif %}
@@ -33,3 +39,6 @@
 </div>
 {% block footer %}
 {% endblock %}
+
+{% url 'helpdesk:delete_kb_category' category.slug as delete_url%}
+{% include 'helpdesk/include/confirm_delete.html' with type="Category" title=category.title delete_url=delete_url %}

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -1,6 +1,16 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
-<h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+<div class="d-flex">
+    <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+    {% if user|is_helpdesk_staff %}
+    <div class="flex-fill d-flex justify-content-end">
+        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        </a>
+    </div>
+    {% endif %}
+</div>
+
 {% endblock %}
 
 <div class="container-fluid">

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -25,8 +25,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -55,5 +55,11 @@
         for (const required_field of document.querySelectorAll('[required]')) {
             document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
         }
+
+        if (document.getElementById('id_slug').disabled == false) {
+            $('#id_name').on('input', function () {
+                $('#id_slug').val($('#id_name').val().toLowerCase().replaceAll(' ', '-'))
+            })
+        }
     </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -2,31 +2,46 @@
 
 {% load i18n bootstrap4form %}
 
-{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+{% block helpdesk_title %}{% blocktrans %}{{ action }} Category{% endblocktrans %} {% endblock %}
 
 {% block helpdesk_breadcrumb %}
 <li class="breadcrumb-item">
     <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
 </li>
-<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} {{ action }} {{ kbcat }}{% endblocktrans %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}
     <div class="col-xs-6">
         <div class="panel panel-default">
-            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+            <div class="panel-body"><h2>{% blocktrans %} {{ action }} Category {% endblocktrans %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
-                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                {% if errors %}
+                <div class="alert alert-danger" role="alert">
+                    <a class="close" data-dismiss="alert">&times;</a>
+                        {% trans "Error in the following field(s): " %}
+                        {% for error in errors %}
+                            {{ error }}{% if not forloop.last %},{% endif %}
+                        {% endfor %}
+                </div>
+                {% endif %}
                 <form method='post'>
                     {% csrf_token %}
                     <fieldset>
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
-                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">
-                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <input type='submit' class="btn btn-primary btn" 
+                                value="{% if action == "Create"%}Create Category{% else %}Save Changes{% endif %}"/>
+                            <a href="
+                            {% if action == "Create"%}
+                                {% url 'helpdesk:kb_index'%}{{ user_info.url }}
+                            {% else %}
+                                {% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}
+                            {% endif %}
+                            ">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel" %}</button>
                             </a>
                         </div>
                     </fieldset>
@@ -34,4 +49,11 @@
             </div>
         </div>
     </div>
+
+    <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+    </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -1,0 +1,37 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/kb_index.html
+++ b/helpdesk/templates/helpdesk/kb_index.html
@@ -15,7 +15,15 @@
     <div class="row">
         <div class="col-sm-8">
 {% endif %}
-            <h2>{% trans "Knowledgebase" %}</h2>
+            <div class="d-flex">
+                <h2>{% trans "Knowledgebase" %}</h2>
+                <div class="flex-fill d-flex justify-content-end">
+                    <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:create_kb_category' %}{{ user_info.url }}">
+                        <i class="fa fa-plus mr-1"></i>Create Category
+                    </a>
+                </div>
+            </div>
+
             <p>{% trans "We have listed a number of Knowledgebase articles for your perusal in the following categories. Please check to see if any of these articles address your problem prior to opening a support ticket." %}</p>
             {% for category in kb_categories %}
             {% cycle 'one' 'two' 'three' as catnumperrow silent %}

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -285,6 +285,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.index,
             name='kb_index'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/create/$',
+            kb.create_article,
+            name='create_kb_article'),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/$',
             kb.article,
             name='kb_article'),
@@ -293,6 +297,14 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.edit_article,
             name="edit_kb_article"),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/delete/$',
+            kb.delete_article,
+            name="delete_kb_article"),
+
+        url(r'^kb/create/$',
+            kb.create_category,
+            name='create_kb_category'),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),
@@ -300,6 +312,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
             kb.edit_category,
             name="edit_kb_category"),
+
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/delete/$',
+            kb.delete_category,
+            name="delete_kb_category"),
 
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -293,6 +293,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.category,
             name='kb_category'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
+            kb.edit_category,
+            name="edit_kb_category"),
+
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,
             name='kb_vote'),

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -289,6 +289,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.article,
             name='kb_article'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/edit/$',
+            kb.edit_article,
+            name="edit_kb_article"),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -158,6 +158,11 @@ def article(request, slug, pk, iframe=False):
         'kb_forms': kb_forms
     })
 
+@helpdesk_staff_member_required
+def edit_article(request, slug, pk, iframe=False):
+
+    # Stub return
+    return
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -233,6 +233,7 @@ def create_article(request, slug):
                 answer = form.cleaned_data['answer'],
                 order = form.cleaned_data['order'],
                 enabled = form.cleaned_data['enabled'],
+                last_updated = datetime.datetime.now()
             )
             item.save()     
         return HttpResponseRedirect(reverse('helpdesk:kb_category', args=[category.slug]))
@@ -272,6 +273,7 @@ def edit_article(request, slug, pk, iframe=False):
             item.answer = form.cleaned_data['answer']
             item.order = form.cleaned_data['order']
             item.enabled = form.cleaned_data['enabled']
+            item.last_updated = datetime.datetime.now()
 
             item.save()
         return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[item.category.slug, item.id]))

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -18,8 +18,10 @@ from helpdesk import settings as helpdesk_settings
 from helpdesk import user
 from helpdesk.models import KBCategory, KBItem
 from helpdesk.decorators import is_helpdesk_staff, helpdesk_staff_member_required
-from helpdesk.forms import EditKBCategoryForm
+from helpdesk.forms import EditKBCategoryForm, EditKBItemForm
 from django.utils.html import escape
+
+import datetime
 
 def index(request):
     huser = user.huser_from_request(request)
@@ -160,9 +162,56 @@ def article(request, slug, pk, iframe=False):
 
 @helpdesk_staff_member_required
 def edit_article(request, slug, pk, iframe=False):
+    item = get_object_or_404(KBItem, pk=pk)
 
-    # Stub return
-    return
+    if request.method == "GET":
+        form = EditKBItemForm(initial={
+            'category': item.category,
+            'title': item.title,
+            'question': item.question,
+            'answer': item.answer,
+            'order': item.order,
+            'enabled': item.enabled,
+        })
+
+        return render(request, 'helpdesk/kb_article_edit.html', {
+            'category': item.category,
+            'item': item,
+            'form': form,
+            'debug': settings.DEBUG,
+        })
+    elif request.method == "POST":
+        form = EditKBItemForm(request.POST, item.category.slug)
+
+        if form.is_valid():
+            category = form.cleaned_data['category']
+            title = form.cleaned_data['title']
+            question = form.cleaned_data['question']
+            answer = form.cleaned_data['answer']
+            order = form.cleaned_data['order']
+            enabled = form.cleaned_data['enabled']
+            voted_by = item.voted_by
+            downvoted_by = item.downvoted_by
+
+            new_item = KBItem(
+                id = item.id,
+                category = category,
+                title = title,
+                question = question,
+                answer = answer,
+                order = order,
+                enabled = enabled,
+                votes = item.votes,
+                recommendations = item.recommendations,
+                team = item.team,
+                last_updated = datetime.datetime.now()
+            )
+            item.delete()
+            new_item.save()
+            new_item.voted_by.set(voted_by.all())
+            new_item.downvoted_by.set(downvoted_by.all())
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -184,33 +184,15 @@ def edit_article(request, slug, pk, iframe=False):
         form = EditKBItemForm(request.POST, item.category.slug)
 
         if form.is_valid():
-            category = form.cleaned_data['category']
-            title = form.cleaned_data['title']
-            question = form.cleaned_data['question']
-            answer = form.cleaned_data['answer']
-            order = form.cleaned_data['order']
-            enabled = form.cleaned_data['enabled']
-            voted_by = item.voted_by
-            downvoted_by = item.downvoted_by
+            item.category = form.cleaned_data['category']
+            item.title = form.cleaned_data['title']
+            item.question = form.cleaned_data['question']
+            item.answer = form.cleaned_data['answer']
+            item.order = form.cleaned_data['order']
+            item.enabled = form.cleaned_data['enabled']
 
-            new_item = KBItem(
-                id = item.id,
-                category = category,
-                title = title,
-                question = question,
-                answer = answer,
-                order = order,
-                enabled = enabled,
-                votes = item.votes,
-                recommendations = item.recommendations,
-                team = item.team,
-                last_updated = datetime.datetime.now()
-            )
-            item.delete()
-            new_item.save()
-            new_item.voted_by.set(voted_by.all())
-            new_item.downvoted_by.set(downvoted_by.all())
-        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            item.save()
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[item.category.slug, item.id]))
             
 
 @xframe_options_exempt


### PR DESCRIPTION
- Added create category button to KB index page.
- Added create article button to KB category page
- Added delete category button to KB category page.
- Added delete article button to KB article page.
- Delete buttons will first open a modal where the user must click another delete button before the delete operation is actually performed: 
![image](https://github.com/ClearlyEnergy/django-helpdesk/assets/82979632/791a91f0-608b-4c6c-a88e-938fb9eb9015)
