### PR TITLE
KB Article: Added markdown preview tab to answer field when creating / editing articles.

### DIFF
--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -92,7 +92,7 @@ class CustomFieldAdminForm(forms.ModelForm):
                 .filter(organization_id=obj.ticket_form.organization_id) \
                 .exclude(table_name='') \
                 .exclude(table_name=None) \
-                .order_by('id')
+                .order_by('column_name')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -276,6 +276,9 @@ class EditKBCategoryForm(forms.ModelForm):
         self.fields['queue'].queryset = Queue.objects.filter(organization=org)
         self.fields['forms'].queryset = FormType.objects.filter(organization=org) 
 
+class PreviewWidget(forms.widgets.Textarea):
+    template_name = "helpdesk/include/edit_md_preview.html"
+
 class EditKBItemForm(forms.ModelForm):
 
     class CategoryModelChoiceField(forms.ModelChoiceField):
@@ -283,6 +286,7 @@ class EditKBItemForm(forms.ModelForm):
             return "%s" % (category.name)
         
     category = CategoryModelChoiceField(queryset=KBCategory.objects)
+    answer = forms.CharField(widget=PreviewWidget, help_text=KBItem.answer.field.help_text)
 
     class Meta:
         model = KBItem
@@ -294,8 +298,8 @@ class EditKBItemForm(forms.ModelForm):
             Filter categories by current org.
             Prepoulate category field when creating a new article from a category's page.
         """
-        org = kwargs.pop('organization') if kwargs and kwargs['organization'] else None
-        category = kwargs.pop('category') if kwargs and kwargs['category'] else None
+        org = kwargs.pop('organization', None)
+        category = kwargs.pop('category', None) 
         super(EditKBItemForm, self).__init__(*args, **kwargs)
 
         self.fields['category'].queryset = KBCategory.objects.filter(organization=org)

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -128,6 +128,8 @@ class CustomFieldMixin(object):
         else:
             self.fields[field.field_name] = fieldclass(**instanceargs)
 
+class PreviewWidget(forms.widgets.Textarea):
+    template_name = "helpdesk/include/edit_md_preview.html"
 
 class EditTicketForm(CustomFieldMixin, forms.ModelForm):
 
@@ -240,6 +242,7 @@ class EditTicketForm(CustomFieldMixin, forms.ModelForm):
 
 
 class EditFollowUpForm(forms.ModelForm):
+    comment = forms.CharField(widget=PreviewWidget, help_text=FollowUp.comment.field.help_text)
 
     class Meta:
         model = FollowUp
@@ -256,6 +259,8 @@ class EditKBCategoryForm(forms.ModelForm):
     error_css_class = 'text-danger'
 
     slug = forms.SlugField()
+    preview_description = forms.CharField(widget=PreviewWidget, help_text=KBCategory.preview_description.field.help_text)
+    description = forms.CharField(widget=PreviewWidget, help_text=KBCategory.description.field.help_text)
 
     class Meta:
         model = KBCategory
@@ -275,9 +280,6 @@ class EditKBCategoryForm(forms.ModelForm):
         
         self.fields['queue'].queryset = Queue.objects.filter(organization=org)
         self.fields['forms'].queryset = FormType.objects.filter(organization=org) 
-
-class PreviewWidget(forms.widgets.Textarea):
-    template_name = "helpdesk/include/edit_md_preview.html"
 
 class EditKBItemForm(forms.ModelForm):
 
@@ -317,6 +319,11 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
     form_introduction = None
     form_queue = None
     hidden_fields = []
+
+    description = forms.CharField(
+        widget=PreviewWidget, 
+        help_text=Ticket.description.field.help_text
+    )
 
     queue = forms.ChoiceField(
         widget=forms.Select(attrs={'class': 'form-control'}),

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -133,6 +133,8 @@ class PreviewWidget(forms.widgets.Textarea):
 
 class EditTicketForm(CustomFieldMixin, forms.ModelForm):
 
+    description = forms.CharField(widget=PreviewWidget, help_text=Ticket.description.field.help_text)
+
     class Meta:
         model = Ticket
         exclude = ('assigned_to', 'created', 'modified', 'status', 'on_hold', 'resolution', 'last_escalation',

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -273,6 +273,28 @@ class EditKBCategoryForm(forms.ModelForm):
         self.fields['queue'].queryset = Queue.objects.filter(organization=org)
         self.fields['forms'].queryset = FormType.objects.filter(organization=org) 
 
+class EditKBItemForm(forms.ModelForm):
+
+    class CategoryModelChoiceField(forms.ModelChoiceField):
+        def label_from_instance(self, category):
+            return "%s" % (category.name)
+        
+    category = CategoryModelChoiceField(queryset=KBCategory.objects)
+
+    class Meta:
+        model = KBItem
+        exclude = ('voted_by', 'downvoted_by', 'votes', 'recommendations', 'last_updated','team')
+
+    def __init__(self, *args, **kwargs):
+        """
+            Category field will only show category titles.
+            Filter categories by current org.
+        """
+        super(EditKBItemForm, self).__init__(*args, **kwargs)
+
+        slug = kwargs['initial']['category'].slug if kwargs else args[1]
+        org = KBCategory.objects.filter(slug=slug).first().organization
+        self.fields['category'].queryset = KBCategory.objects.filter(organization=org)
 
 class AbstractTicketForm(CustomFieldMixin, forms.Form):
     """

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -266,7 +266,7 @@ class EditKBCategoryForm(forms.ModelForm):
             Set slug field to read-only. 
             Filter queues and forms by current org.
         """
-        org = kwargs.pop('organization') if kwargs and kwargs['organization'] else None
+        org = kwargs.pop('organization', None)
         super(EditKBCategoryForm, self).__init__(*args, **kwargs)
 
         if action == "edit":

--- a/helpdesk/templates/helpdesk/followup_edit.html
+++ b/helpdesk/templates/helpdesk/followup_edit.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}
+{% extends "helpdesk/base.html" %}{% load i18n bootstrap4form %}
 {% block helpdesk_title %}{% trans "Edit followup" %}{% endblock %}
 
 {% block helpdesk_head %}
@@ -33,22 +33,7 @@
         <form action="." method="POST" name="edit_followup_form">
             {{ form.non_field_errors }}
             <fieldset>
-            <dl>
-                <dt><label for='id_ticket'>{% trans "Reassign ticket:" %}</label></dt>
-                <dd>{{ form.ticket }}</dd>
-                <dt><label for="id_title">{% trans "Title:" %}</label></dt>
-                <dd>{{ form.title }}</dd>
-                <dt><label for="id_comment">{% trans "Comment:" %}</label></dt>
-                <dd>{{ form.comment }}</dd>
-                <dt><label for="id_public">Public:</label></dt>
-                <dd>{{ form.public }}</dd>
-                    <p>Public tickets are viewable by the submitter and all staff, but non-public tickets can only be seen by staff.</p>
-                <dt><label for="id_new_status">New Status:</label></dt>
-                <dd>{{ form.new_status }}</dd>
-                    <p>If the status was changed, what was it changed to?</p>
-                <dt><label for="id_time_spent">Time spent:</label></dt>
-                <dd>{{ form.time_spent }}</dd>
-            </dl>
+                {{ form|bootstrap4form}}
             </fieldset>
             <p><input class="btn btn-primary btn-sm" type="submit" value="Submit"></p>{% csrf_token %}
         </form>

--- a/helpdesk/templates/helpdesk/include/comment_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/comment_md_preview.html
@@ -1,0 +1,33 @@
+<div class="card">
+    <div class="card-header">
+        <ul class="nav nav-tabs card-header-tabs" data-bs-tabs="tabs">
+            <li class="nav-item">
+                <a class="nav-link active" data-toggle="tab" href="#comment_edit">Edit</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" data-toggle="tab" href="#comment_preview" onclick="updatePreview_comment()">Preview</a>
+            </li>
+        </ul>
+    </div>
+    <div class="card-body tab-content" style='max-height: 50vh; overflow-y: auto'>
+        <div id="comment_edit" class="tab-pane active">
+            <textarea class="form-control" name="comment" id="commentBox" cols="40" rows="10" spellcheck="false" data-ms-editor="true"></textarea>
+        </div>
+        <div id="comment_preview" class="tab-pane">
+            <div id="comment_md_preview"></div>
+        </div>
+    </div>
+</div>
+
+<script type='text/javascript' language='javascript'>
+    function updatePreview_comment() {
+        $.ajax({
+            data: {md: $('#commentBox').val()},
+            url: "{% url 'helpdesk:preview_markdown'  %}",
+
+            success: function(response) {
+                $('#comment_md_preview').html(response['md_html'])
+            },
+        });
+    }
+</script>

--- a/helpdesk/templates/helpdesk/include/confirm_delete.html
+++ b/helpdesk/templates/helpdesk/include/confirm_delete.html
@@ -1,0 +1,25 @@
+<div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteModalLabel">Confirm {{ type }} Deletion</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>
+                    Please confirm that you want to delete the {{ type }}: <strong>{{ title }}</strong>. 
+                    </br> </br>
+                    This action <strong>cannot</strong> be undone.
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <a href="{{ delete_url }}">
+                    <button type="button"  class="btn btn-danger">Delete {{ type }}</button>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -12,8 +12,8 @@
     <div class="card-body tab-content" style='max-height: 50vh; overflow-y: auto'>
         <div id="{{widget.name}}_edit" class="tab-pane active">
             <textarea class="form-control" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% spaceless %}
-                {% if widget.value %}{{ widget.value }}{% endif %}{% endspaceless %}
-            </textarea>
+                {% if widget.value %}{{ widget.value }}{% endif %}
+            {% endspaceless %}</textarea>
         </div>
         <div id="{{widget.name}}_preview" class="tab-pane">
             <div id="{{widget.name}}_md_preview"></div>

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -2,25 +2,27 @@
     <div class="card-header">
         <ul class="nav nav-tabs card-header-tabs" data-bs-tabs="tabs">
             <li class="nav-item">
-                <a class="nav-link active" data-toggle="tab" href="#edit">Edit</a>
+                <a class="nav-link active" data-toggle="tab" href="#{{widget.name}}_edit">Edit</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" data-toggle="tab" href="#preview" onclick="updatePreview()">Preview</a>
+                <a class="nav-link" data-toggle="tab" href="#{{widget.name}}_preview" onclick="updatePreview_{{widget.name}}()">Preview</a>
             </li>
         </ul>
     </div>
     <div class="card-body tab-content" style='max-height: 50vh; overflow-y: auto'>
-        <div id="edit" class="tab-pane active">
-            {% include "django/forms/widgets/textarea.html" with widget=widget %}
+        <div id="{{widget.name}}_edit" class="tab-pane active">
+            <textarea class="form-control" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% spaceless %}
+                {% if widget.value %}{{ widget.value }}{% endif %}{% endspaceless %}
+            </textarea>
         </div>
-        <div id="preview" class="tab-pane">
+        <div id="{{widget.name}}_preview" class="tab-pane">
             <div id="{{widget.name}}_md_preview"></div>
         </div>
     </div>
 </div>
 
 <script type='text/javascript' language='javascript'>
-    function updatePreview() {
+    function updatePreview_{{widget.name}}() {
         $.ajax({
             data: {md: $('#id_{{widget.name}}').val()},
             url: "{% url 'helpdesk:preview_markdown'  %}",

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -1,21 +1,25 @@
-<div class="row">
-    <div class="col-md-6">
-        {% include "django/forms/widgets/textarea.html" with widget=widget %}
+<div class="card">
+    <div class="card-header">
+        <ul class="nav nav-tabs card-header-tabs" data-bs-tabs="tabs">
+            <li class="nav-item">
+                <a class="nav-link active" data-toggle="tab" href="#edit">Edit</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" data-toggle="tab" href="#preview" onclick="updatePreview()">Preview</a>
+            </li>
+        </ul>
     </div>
-    <div class="col-md-6 mt-md-0 mt-2">
-        <div id="preview_card" class="card px-1 py-1 h-100" style="overflow: auto;">
+    <div class="card-body tab-content">
+        <div id="edit" class="tab-pane active">
+            {% include "django/forms/widgets/textarea.html" with widget=widget %}
+        </div>
+        <div id="preview" class="tab-pane">
             <div id="{{widget.name}}_md_preview"></div>
         </div>
     </div>
 </div>
 
 <script type='text/javascript' language='javascript'>
-    $(document).ready(function () {
-        updateMaxHeight();
-        updatePreview();
-        $('#id_{{widget.name}}').on({'keyup': updatePreview, 'mouseup mousemove': updateMaxHeight});
-    });
-
     function updatePreview() {
         $.ajax({
             data: {md: $('#id_{{widget.name}}').val()},
@@ -25,9 +29,5 @@
                 $('#{{widget.name}}_md_preview').html(response['md_html'])
             },
         });
-    }
-
-    function updateMaxHeight() {
-        $('#preview_card').css({'max-height': document.getElementById('id_{{widget.name}}').clientHeight});
     }
 </script>

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -1,0 +1,34 @@
+<div class="row">
+    <div class="col-md-6">
+        {% include "django/forms/widgets/textarea.html" with widget=widget %}
+    </div>
+    <div class="col-md-6 mt-md-0 mt-2">
+        <div id="preview_card" class="card px-1 py-1 h-100" style="overflow: auto;">
+            <div id="{{widget.name}}_md_preview"></div>
+        </div>
+    </div>
+</div>
+
+<script type='text/javascript' language='javascript'>
+    $(document).ready(function () {
+        updateMaxHeight();
+        updatePreview();
+        $('#id_{{widget.name}}').on({'keyup': updatePreview, 'mouseup mousemove': updateMaxHeight});
+    });
+
+    function updatePreview() {
+        $.ajax({
+            data: {md: $('#id_{{widget.name}}').val()},
+            url: "{% url 'helpdesk:preview_markdown'  %}",
+
+            success: function(response) {
+                console.log(response)
+                $('#{{widget.name}}_md_preview').html(response['md_html'])
+            },
+        });
+    }
+
+    function updateMaxHeight() {
+        $('#preview_card').css({'max-height': document.getElementById('id_{{widget.name}}').clientHeight});
+    }
+</script>

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -22,7 +22,6 @@
             url: "{% url 'helpdesk:preview_markdown'  %}",
 
             success: function(response) {
-                console.log(response)
                 $('#{{widget.name}}_md_preview').html(response['md_html'])
             },
         });

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -22,10 +22,12 @@
 </div>
 
 <script type='text/javascript' language='javascript'>
+    console.log("{{ item }}")
+    is_kbitem = document.getElementById('id_answer') != null
     function updatePreview_{{widget.name}}() {
         $.ajax({
-            data: {md: $('#id_{{widget.name}}').val()},
-            url: "{% url 'helpdesk:preview_markdown'  %}",
+            data: {md: $('#id_{{widget.name}}').val(), is_kbitem: is_kbitem},
+            url: "{% url 'helpdesk:preview_markdown' %}",
 
             success: function(response) {
                 $('#{{widget.name}}_md_preview').html(response['md_html'])

--- a/helpdesk/templates/helpdesk/include/edit_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/edit_md_preview.html
@@ -9,7 +9,7 @@
             </li>
         </ul>
     </div>
-    <div class="card-body tab-content">
+    <div class="card-body tab-content" style='max-height: 50vh; overflow-y: auto'>
         <div id="edit" class="tab-pane active">
             {% include "django/forms/widgets/textarea.html" with widget=widget %}
         </div>

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -1,8 +1,15 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
 <div class="row" style="display:inline">
-    <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
-    <a style="vertial-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
+    <div class="d-flex">
+        <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
+        <div class="flex-fill d-flex justify-content-end">
+            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
+                <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+            </a>
+        </div>
+    </div>
+    <a style="vertical-align:center" class="btn btn-secondary btn-sm{% if not prev_item %} disabled{% endif %}" href="{{ prev_item.get_absolute_url }}/{{ user_info.url }}" role="button">
         <i class="fa fa-angle-double-left"></i> Previous Item
     </a>
     <a class="btn btn-secondary btn-sm{% if not next_item %} disabled{% endif %}" href="{{ next_item.get_absolute_url }}/{{ user_info.url }}">

--- a/helpdesk/templates/helpdesk/kb_article_base.html
+++ b/helpdesk/templates/helpdesk/kb_article_base.html
@@ -4,8 +4,11 @@
     <div class="d-flex">
         <h2>{% blocktrans with item.question as itemq %}{{ itemq }}{% endblocktrans %}</h2>
         <div class="flex-fill d-flex justify-content-end">
-            <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
-                <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+            <a class="btn btn-primary align-self-center mr-2" href="{% url 'helpdesk:edit_kb_article' category.slug item.id %}{{ user_info.url }}">
+                <i class="fa fa-pen mr-1"></i>Edit Article
+            </a>
+            <a class="btn btn-danger align-self-center" data-toggle="modal" data-target="#deleteModal">
+                <i class="fa fa-trash mr-1"></i>Delete Article
             </a>
         </div>
     </div>
@@ -43,3 +46,6 @@
 </div>
 {% block footer %}
 {% endblock %}
+
+{% url 'helpdesk:delete_kb_article' category.slug item.id as delete_url%}
+{% include 'helpdesk/include/confirm_delete.html' with type="Article" title=item.title delete_url=delete_url %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -1,0 +1,40 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">
+    <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} Edit: {{ itemq }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -19,7 +19,7 @@
         <div class="panel panel-default">
             <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
                 {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
                 <form method='post'>
@@ -37,4 +37,11 @@
             </div>
         </div>
     </div>
+
+    <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+    </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -28,8 +28,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_article_edit.html
+++ b/helpdesk/templates/helpdesk/kb_article_edit.html
@@ -2,7 +2,7 @@
 
 {% load i18n bootstrap4form %}
 
-{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+{% block helpdesk_title %}{% blocktrans %}{{ action }} Article{% endblocktrans %}{% endblock %}
 
 {% block helpdesk_breadcrumb %}
 <li class="breadcrumb-item">
@@ -11,13 +11,13 @@
 <li class="breadcrumb-item active">
     <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</a>
 </li>
-<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} Edit: {{ itemq }}{% endblocktrans %}</li>
+<li class="breadcrumb-item active">{% blocktrans with item.question as itemq %} {{ action }} {{ itemq }}{% endblocktrans %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}
     <div class="col-xs-6">
         <div class="panel panel-default">
-            <div class="panel-body"><h2>{% trans "Edit Article" %}</h2>
+            <div class="panel-body"><h2>{% blocktrans %} {{ action }} Article {% endblocktrans %}</h2>
                 <p>
                     {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
@@ -27,9 +27,16 @@
                     <fieldset>
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
-                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href="{% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}">
-                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <input type='submit' class="btn btn-primary btn" 
+                                value="{% if action == "Create"%}Create Article{% else %}Save Changes{% endif %}"/>
+                            <a href="
+                            {% if action == "Create"%}
+                                {% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}
+                            {% else %}
+                                {% url 'helpdesk:kb_article' category.slug item.id %}{{ user_info.url }}
+                            {% endif %}
+                            ">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -4,8 +4,14 @@
     <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
     {% if user|is_helpdesk_staff %}
     <div class="flex-fill d-flex justify-content-end">
-        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
-            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        <a class="btn btn-primary align-self-center mr-2" href="{% url 'helpdesk:create_kb_article' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-plus mr-1"></i>Create Article
+        </a>
+        <a class="btn btn-primary align-self-center mr-2" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen mr-1" ></i>Edit Category
+        </a>
+        <a class="btn btn-danger align-self-center" data-toggle="modal" data-target="#deleteModal">
+            <i class="fa fa-trash mr-1"></i>Delete Category
         </a>
     </div>
     {% endif %}
@@ -33,3 +39,6 @@
 </div>
 {% block footer %}
 {% endblock %}
+
+{% url 'helpdesk:delete_kb_category' category.slug as delete_url%}
+{% include 'helpdesk/include/confirm_delete.html' with type="Category" title=category.title delete_url=delete_url %}

--- a/helpdesk/templates/helpdesk/kb_category_base.html
+++ b/helpdesk/templates/helpdesk/kb_category_base.html
@@ -1,6 +1,16 @@
 {% load i18n helpdesk_staff %}
 {% block header %}
-<h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+<div class="d-flex">
+    <h2>{% blocktrans with category.title as kbcat %}{{ kbcat }}{% endblocktrans %}</h2>
+    {% if user|is_helpdesk_staff %}
+    <div class="flex-fill d-flex justify-content-end">
+        <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:edit_kb_category' category.slug %}{{ user_info.url }}">
+            <i class="fa fa-pen" style="margin-right:0.25rem"></i>Edit
+        </a>
+    </div>
+    {% endif %}
+</div>
+
 {% endblock %}
 
 <div class="container-fluid">

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -25,8 +25,8 @@
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
                             <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href='{{ ticket.get_absolute_url }}'>
-                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
                             </a>
                         </div>
                     </fieldset>

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -2,31 +2,46 @@
 
 {% load i18n bootstrap4form %}
 
-{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+{% block helpdesk_title %}{% blocktrans %}{{ action }} Category{% endblocktrans %} {% endblock %}
 
 {% block helpdesk_breadcrumb %}
 <li class="breadcrumb-item">
     <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
 </li>
-<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} {{ action }} {{ kbcat }}{% endblocktrans %}</li>
 {% endblock %}
 
 {% block helpdesk_body %}
     <div class="col-xs-6">
         <div class="panel panel-default">
-            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+            <div class="panel-body"><h2>{% blocktrans %} {{ action }} Category {% endblocktrans %}</h2>
                 <p>
-                    {% trans "Unless otherwise stated, all fields are required." %}
+                    {% trans "Required fields are indicated by " %} <span style="color:red;">*</span>
                 </p>
-                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                {% if errors %}
+                <div class="alert alert-danger" role="alert">
+                    <a class="close" data-dismiss="alert">&times;</a>
+                        {% trans "Error in the following field(s): " %}
+                        {% for error in errors %}
+                            {{ error }}{% if not forloop.last %},{% endif %}
+                        {% endfor %}
+                </div>
+                {% endif %}
                 <form method='post'>
                     {% csrf_token %}
                     <fieldset>
                         {{ form|bootstrap4form }}
                         <div class='buttons form-group'>
-                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
-                            <a href="{% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}">
-                                <button type="button" class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            <input type='submit' class="btn btn-primary btn" 
+                                value="{% if action == "Create"%}Create Category{% else %}Save Changes{% endif %}"/>
+                            <a href="
+                            {% if action == "Create"%}
+                                {% url 'helpdesk:kb_index'%}{{ user_info.url }}
+                            {% else %}
+                                {% url 'helpdesk:kb_category' category.slug %}{{ user_info.url }}
+                            {% endif %}
+                            ">
+                                <button type="button" class="btn btn-danger">{% trans "Cancel" %}</button>
                             </a>
                         </div>
                     </fieldset>
@@ -34,4 +49,11 @@
             </div>
         </div>
     </div>
+
+    <script type='text/javascript' language='javascript'>
+        {# Bandaid fix for adding asterisks to required fields while the rest of the form is handled by bootstrap4form #}
+        for (const required_field of document.querySelectorAll('[required]')) {
+            document.querySelector('label[for=' + required_field.id + ']').innerHTML += '<span style="color:red;">*</span>'
+        }
+    </script>
 {% endblock %}

--- a/helpdesk/templates/helpdesk/kb_category_edit.html
+++ b/helpdesk/templates/helpdesk/kb_category_edit.html
@@ -1,0 +1,37 @@
+{% extends "helpdesk/base.html" %}
+
+{% load i18n bootstrap4form %}
+
+{% block helpdesk_title %}{% trans "Edit Category" %}{% endblock %}
+
+{% block helpdesk_breadcrumb %}
+<li class="breadcrumb-item">
+    <a href="{% url 'helpdesk:kb_index' %}{{ user_info.url }}">{% trans "Knowledgebase" %}</a>
+</li>
+<li class="breadcrumb-item active">{% blocktrans with category.title as kbcat %} Edit: {{ kbcat }}{% endblocktrans %}</li>
+{% endblock %}
+
+{% block helpdesk_body %}
+    <div class="col-xs-6">
+        <div class="panel panel-default">
+            <div class="panel-body"><h2>{% trans "Edit Category" %}</h2>
+                <p>
+                    {% trans "Unless otherwise stated, all fields are required." %}
+                </p>
+                {% if errors %}<p class="text-danger">{% for error in errors %}{% trans "Error: " %}{{ error }}<br>{% endfor %}</p>{% endif %}
+                <form method='post'>
+                    {% csrf_token %}
+                    <fieldset>
+                        {{ form|bootstrap4form }}
+                        <div class='buttons form-group'>
+                            <input type='submit' class="btn btn-primary btn" value='{% trans "Save Changes" %}'/>
+                            <a href='{{ ticket.get_absolute_url }}'>
+                                <button class="btn btn-danger">{% trans "Cancel Changes" %}</button>
+                            </a>
+                        </div>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/helpdesk/templates/helpdesk/kb_index.html
+++ b/helpdesk/templates/helpdesk/kb_index.html
@@ -15,7 +15,15 @@
     <div class="row">
         <div class="col-sm-8">
 {% endif %}
-            <h2>{% trans "Knowledgebase" %}</h2>
+            <div class="d-flex">
+                <h2>{% trans "Knowledgebase" %}</h2>
+                <div class="flex-fill d-flex justify-content-end">
+                    <a class="btn btn-primary align-self-center" href="{% url 'helpdesk:create_kb_category' %}{{ user_info.url }}">
+                        <i class="fa fa-plus mr-1"></i>Create Category
+                    </a>
+                </div>
+            </div>
+
             <p>{% trans "We have listed a number of Knowledgebase articles for your perusal in the following categories. Please check to see if any of these articles address your problem prior to opening a support ticket." %}</p>
             {% for category in kb_categories %}
             {% cycle 'one' 'two' 'three' as catnumperrow silent %}

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -114,8 +114,10 @@
                 <small>{% trans "Selecting a preset reply will overwrite your comment below. You can then modify the preset reply to your liking before saving this update." %}</small></dd>
                 {% endif %}
 
+
+                
                 <dt><label for='commentBox'>{% trans "Comment / Resolution" %}</label></dt>
-                <dd><textarea rows='8' cols='70' name='comment' id='commentBox' class='form-control'></textarea></dd>
+                <dd>{% include 'helpdesk/include/comment_md_preview.html' %}</dd>
                 <dd class='form_help_text'><small>{% trans "You can insert ticket and queue details in your message. For more information, see the <a href='../../help/context/'>context help page</a>." %}</small></dd>
 
                 <dt><label>{% trans "Change Ticket Status" %}</label></dt>

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -110,12 +110,12 @@
 
                 {% if preset_replies %}
                 <dd><label for='id_preset'><b>{% trans "Use a Preset Reply?" %}</b></label>
-                <select name='preset' id='id_preset'><option value=''>------</option>{% for preset in preset_replies %}<option value='{{ preset.id }}'>{{ preset.name }}</option>{% endfor %}</select><br/>
+                <select name='preset' id='id_preset' class='form-control'><option value=''>------</option>{% for preset in preset_replies %}<option value='{{ preset.id }}'>{{ preset.name }}</option>{% endfor %}</select><br/>
                 <small>{% trans "Selecting a preset reply will overwrite your comment below. You can then modify the preset reply to your liking before saving this update." %}</small></dd>
                 {% endif %}
 
                 <dt><label for='commentBox'>{% trans "Comment / Resolution" %}</label></dt>
-                <dd><textarea rows='8' cols='70' name='comment' id='commentBox'></textarea></dd>
+                <dd><textarea rows='8' cols='70' name='comment' id='commentBox' class='form-control'></textarea></dd>
                 <dd class='form_help_text'><small>{% trans "You can insert ticket and queue details in your message. For more information, see the <a href='../../help/context/'>context help page</a>." %}</small></dd>
 
                 <dt><label>{% trans "Change Ticket Status" %}</label></dt>

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -285,6 +285,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.index,
             name='kb_index'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/create/$',
+            kb.create_article,
+            name='create_kb_article'),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/$',
             kb.article,
             name='kb_article'),
@@ -293,6 +297,14 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.edit_article,
             name="edit_kb_article"),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/delete/$',
+            kb.delete_article,
+            name="delete_kb_article"),
+
+        url(r'^kb/create/$',
+            kb.create_category,
+            name='create_kb_category'),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),
@@ -300,6 +312,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
             kb.edit_category,
             name="edit_kb_category"),
+
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/delete/$',
+            kb.delete_category,
+            name="delete_kb_category"),
 
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -297,6 +297,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.edit_article,
             name="edit_kb_article"),
 
+        url(r'^kb/preview_markdown$',
+            kb.preview_markdown,
+            name="preview_markdown"),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/delete/$',
             kb.delete_article,
             name="delete_kb_article"),

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -293,6 +293,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.category,
             name='kb_category'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/edit/$',
+            kb.edit_category,
+            name="edit_kb_category"),
+
         url(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,
             name='kb_vote'),

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -289,6 +289,10 @@ if helpdesk_settings.HELPDESK_KB_ENABLED:
             kb.article,
             name='kb_article'),
 
+        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/(?P<pk>[0-9]+)/edit/$',
+            kb.edit_article,
+            name="edit_kb_article"),
+
         url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -158,6 +158,11 @@ def article(request, slug, pk, iframe=False):
         'kb_forms': kb_forms
     })
 
+@helpdesk_staff_member_required
+def edit_article(request, slug, pk, iframe=False):
+
+    # Stub return
+    return
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -285,7 +285,8 @@ def delete_article(request, slug, pk):
     return HttpResponseRedirect(reverse('helpdesk:kb_category', args=[slug]))
 
 def preview_markdown(request):
-    answer = request.GET.get('md')
+    md = request.GET.get('md')
+    is_kbitem = request.GET.get('is_kbitem', 'false')
     org = request.user.default_organization
 
     class MarkdownNumbers(object):
@@ -296,20 +297,20 @@ def preview_markdown(request):
         def __call__(self, match):
                 self.count += 1
                 return self.pattern.format(self.count)
-
-    import re
-    title_pattern = r'!~!'
-    body_pattern = r'~!~'
-    title = "{{: .card .btn .btn-link style='text-align: left;' " \
-            "data-toggle='collapse' data-target='#collapse{0}' role='region' " \
-            "aria-expanded='false' aria-controls='collapse{0}' .card-header #header{0} .h5 .mb-0 }}"
-    body = "{{ #collapse{0} .collapse role='region' aria-labelledby='header{0}' data-parent='#header{0}' " \
-           "style='padding-top:0;padding-bottom:0;margin:0;' .card-body }}"
-    new_answer, title_count = re.subn(title_pattern, MarkdownNumbers(start=1, pattern=title), answer)
-    new_answer, body_count = re.subn(body_pattern, MarkdownNumbers(start=1, pattern=body), new_answer)
-    if title_count != 0 and title_count == body_count:
-        return JsonResponse({'md_html':get_markdown(new_answer, org, kb=True)})
-    return JsonResponse({'md_html':get_markdown(answer, org)})
+    if is_kbitem == 'true':
+        import re
+        title_pattern = r'!~!'
+        body_pattern = r'~!~'
+        title = "{{: .card .btn .btn-link style='text-align: left;' " \
+                "data-toggle='collapse' data-target='#collapse{0}' role='region' " \
+                "aria-expanded='false' aria-controls='collapse{0}' .card-header #header{0} .h5 .mb-0 }}"
+        body = "{{ #collapse{0} .collapse role='region' aria-labelledby='header{0}' data-parent='#header{0}' " \
+               "style='padding-top:0;padding-bottom:0;margin:0;' .card-body }}"
+        new_md, title_count = re.subn(title_pattern, MarkdownNumbers(start=1, pattern=title), md)
+        new_md, body_count = re.subn(body_pattern, MarkdownNumbers(start=1, pattern=body), new_md)
+        if title_count != 0 and title_count == body_count:
+            return JsonResponse({'md_html':get_markdown(new_md, org, kb=True)})
+    return JsonResponse({'md_html':get_markdown(md, org)})
 
 
 @xframe_options_exempt

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -9,14 +9,14 @@ views/kb.py - Public-facing knowledgebase views. The knowledgebase is a
 """
 
 from django.conf import settings
-from django.http import HttpResponseRedirect, Http404
+from django.http import HttpResponseRedirect, Http404, JsonResponse
 from django.shortcuts import render, get_object_or_404
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.urls import reverse
 
 from helpdesk import settings as helpdesk_settings
 from helpdesk import user
-from helpdesk.models import KBCategory, KBItem
+from helpdesk.models import KBCategory, KBItem, get_markdown
 from helpdesk.decorators import is_helpdesk_staff, helpdesk_staff_member_required
 from helpdesk.forms import EditKBCategoryForm, EditKBItemForm
 from django.utils.html import escape
@@ -230,7 +230,7 @@ def create_article(request, slug):
                 category = form.cleaned_data['category'],
                 title = form.cleaned_data['title'],
                 question = form.cleaned_data['question'],
-                answer = form.cleaned_data['answer'],
+                answer = escape(form.cleaned_data['answer']),
                 order = form.cleaned_data['order'],
                 enabled = form.cleaned_data['enabled'],
             )
@@ -281,6 +281,34 @@ def delete_article(request, slug, pk):
     item = get_object_or_404(KBItem, pk=pk)
     item.delete()
     return HttpResponseRedirect(reverse('helpdesk:kb_category', args=[slug]))
+
+def preview_markdown(request):
+    answer = request.GET.get('md')
+    org = request.user.default_organization
+
+    class MarkdownNumbers(object):
+        def __init__(self, start=1, pattern=''):
+            self.count = start - 1
+            self.pattern = pattern
+
+        def __call__(self, match):
+                self.count += 1
+                return self.pattern.format(self.count)
+
+    import re
+    title_pattern = r'!~!'
+    body_pattern = r'~!~'
+    title = "{{: .card .btn .btn-link style='text-align: left;' " \
+            "data-toggle='collapse' data-target='#collapse{0}' role='region' " \
+            "aria-expanded='false' aria-controls='collapse{0}' .card-header #header{0} .h5 .mb-0 }}"
+    body = "{{ #collapse{0} .collapse role='region' aria-labelledby='header{0}' data-parent='#header{0}' " \
+           "style='padding-top:0;padding-bottom:0;margin:0;' .card-body }}"
+    new_answer, title_count = re.subn(title_pattern, MarkdownNumbers(start=1, pattern=title), answer)
+    new_answer, body_count = re.subn(body_pattern, MarkdownNumbers(start=1, pattern=body), new_answer)
+    if title_count != 0 and title_count == body_count:
+        return JsonResponse({'md_html':get_markdown(new_answer, org, kb=True)})
+    return JsonResponse({'md_html':get_markdown(answer, org)})
+
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -18,8 +18,10 @@ from helpdesk import settings as helpdesk_settings
 from helpdesk import user
 from helpdesk.models import KBCategory, KBItem
 from helpdesk.decorators import is_helpdesk_staff, helpdesk_staff_member_required
-from helpdesk.forms import EditKBCategoryForm
+from helpdesk.forms import EditKBCategoryForm, EditKBItemForm
 from django.utils.html import escape
+
+import datetime
 
 def index(request):
     huser = user.huser_from_request(request)
@@ -160,9 +162,56 @@ def article(request, slug, pk, iframe=False):
 
 @helpdesk_staff_member_required
 def edit_article(request, slug, pk, iframe=False):
+    item = get_object_or_404(KBItem, pk=pk)
 
-    # Stub return
-    return
+    if request.method == "GET":
+        form = EditKBItemForm(initial={
+            'category': item.category,
+            'title': item.title,
+            'question': item.question,
+            'answer': item.answer,
+            'order': item.order,
+            'enabled': item.enabled,
+        })
+
+        return render(request, 'helpdesk/kb_article_edit.html', {
+            'category': item.category,
+            'item': item,
+            'form': form,
+            'debug': settings.DEBUG,
+        })
+    elif request.method == "POST":
+        form = EditKBItemForm(request.POST, item.category.slug)
+
+        if form.is_valid():
+            category = form.cleaned_data['category']
+            title = form.cleaned_data['title']
+            question = form.cleaned_data['question']
+            answer = form.cleaned_data['answer']
+            order = form.cleaned_data['order']
+            enabled = form.cleaned_data['enabled']
+            voted_by = item.voted_by
+            downvoted_by = item.downvoted_by
+
+            new_item = KBItem(
+                id = item.id,
+                category = category,
+                title = title,
+                question = question,
+                answer = answer,
+                order = order,
+                enabled = enabled,
+                votes = item.votes,
+                recommendations = item.recommendations,
+                team = item.team,
+                last_updated = datetime.datetime.now()
+            )
+            item.delete()
+            new_item.save()
+            new_item.voted_by.set(voted_by.all())
+            new_item.downvoted_by.set(downvoted_by.all())
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            
 
 @xframe_options_exempt
 def category_iframe(request, slug):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -184,33 +184,15 @@ def edit_article(request, slug, pk, iframe=False):
         form = EditKBItemForm(request.POST, item.category.slug)
 
         if form.is_valid():
-            category = form.cleaned_data['category']
-            title = form.cleaned_data['title']
-            question = form.cleaned_data['question']
-            answer = form.cleaned_data['answer']
-            order = form.cleaned_data['order']
-            enabled = form.cleaned_data['enabled']
-            voted_by = item.voted_by
-            downvoted_by = item.downvoted_by
+            item.category = form.cleaned_data['category']
+            item.title = form.cleaned_data['title']
+            item.question = form.cleaned_data['question']
+            item.answer = form.cleaned_data['answer']
+            item.order = form.cleaned_data['order']
+            item.enabled = form.cleaned_data['enabled']
 
-            new_item = KBItem(
-                id = item.id,
-                category = category,
-                title = title,
-                question = question,
-                answer = answer,
-                order = order,
-                enabled = enabled,
-                votes = item.votes,
-                recommendations = item.recommendations,
-                team = item.team,
-                last_updated = datetime.datetime.now()
-            )
-            item.delete()
-            new_item.save()
-            new_item.voted_by.set(voted_by.all())
-            new_item.downvoted_by.set(downvoted_by.all())
-        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[category.slug, new_item.id]))
+            item.save()
+        return HttpResponseRedirect(reverse('helpdesk:kb_article', args=[item.category.slug, item.id]))
             
 
 @xframe_options_exempt


### PR DESCRIPTION
User input markdown is translated to HTML through an AJAX call to Django. The preview tab will expand with the content up to 50% of the user's display height, at which point it will become scrollable.

https://github.com/ClearlyEnergy/django-helpdesk/assets/82979632/d6553f7d-50e8-477f-924c-05a4be679a78

