### PR TITLE
Emails: bug fix

### DIFF
--- a/helpdesk/email.py
+++ b/helpdesk/email.py
@@ -1373,7 +1373,7 @@ def process_google_message(message, importer, queues, logger, msg_id, server):
 
     # Get subject, sender, to_list, cc_list
     for header in headers:
-        if header['name'] == 'Subject':
+        if header['name'] == 'Subject' or header['name'] == 'subject':
             subject = header['value']
             for affix in STRIPPED_SUBJECT_STRINGS:
                 subject = subject.replace(affix, "")
@@ -1397,7 +1397,7 @@ def process_google_message(message, importer, queues, logger, msg_id, server):
     # Sort out which queue this email should go into #
     ticket, queue = None, None
     for q in queues['importer_queues']:
-        matchobj = re.match(r".*\[" + q.slug + r"-(?P<id>\d+)\]", subject)
+        matchobj = re.match(r".*\[" + q.slug + r"-(?P<id>\d+)\]", subject) if subject else None
         if matchobj and not ticket:
             ticket = matchobj.group('id')
             queue = q


### PR DESCRIPTION
#### Context
CO had an email or multiple emails waiting to be imported that kept throwing errors. Checked the header and instead of `Subject` it had `subject`. Added some quick code on the server to account for that, and reran `get_email`, which succeeded. 

#### What's this PR do?
- Add subject portion of logic check to be case-insensitive.
- Just in case a subject is ever not included, added a check to skip the regexp matching.

#### Do you want someone to review this before it gets merged in?
Yes

#### Questions
- It is possible to use `string.lower()`; is it always guaranteed headers will have strings/data. Should empty headers be skipped if not?
- These issues could probably happen with the other headers and with the other importer functions. Is there a need to worry about those? Fix them when they happen? 

Email land is so spooky lol. Marking this as draft in the meantime