### PR TITLE
Fix filter report by query

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -2370,7 +2370,7 @@ def run_report(request, report):
         charttype = 'date'
 
     elif report == 'daysuntilticketclosedbymonth':
-        title = _('Days until ticket closed by Month')
+        title = _('Average days until ticket was closed (by created month)')
         col1heading = _('Queue')
         possible_options = periods
         charttype = 'date'
@@ -2444,9 +2444,9 @@ def run_report(request, report):
         data = []
         for hdr in possible_options:
             if hdr not in totals.keys():
-                totals[hdr] = summarytable[item, hdr]
+                totals[hdr] = summarytable[item, hdr] or 0
             else:
-                totals[hdr] += summarytable[item, hdr]
+                totals[hdr] += summarytable[item, hdr] or 0
             data.append(summarytable[item, hdr])
         table.append([item] + data)
 

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -2065,10 +2065,10 @@ class QueryLoadError(Exception):
 def load_saved_query(request, query_params=None):
     saved_query = None
 
-    if request.GET.get('saved-query', None):
+    if request.GET.get('saved_query', None):
         try:
             saved_query = SavedSearch.objects.get(
-                Q(pk=request.GET.get('saved-query')) &
+                Q(pk=request.GET.get('saved_query')) &
                 ((Q(shared=True) & ~Q(opted_out_users__in=[request.user])) | Q(user=request.user))
             )
         except (SavedSearch.DoesNotExist, ValueError):
@@ -2296,8 +2296,8 @@ def run_report(request, report):
     except QueryLoadError:
         return HttpResponseRedirect(reverse('helpdesk:report_index'))
 
-    if request.GET.get('saved-query', None):
-        Query(report_queryset, query_to_base64(query_params))
+    if request.GET.get('saved_query', None):
+        report_queryset = Query(report_queryset, query_to_base64(query_params)).__run__(report_queryset)
 
     from collections import defaultdict
     summarytable = defaultdict(int)


### PR DESCRIPTION
Bug Fixes for the following tickets:
- [HD Reports: Filter reports by query doesn't work; just reloads page for all tickets](https://clearlyenergy-inc.monday.com/boards/5290716790/pulses/6013717311)
- [HD: In the “Days until ticket closed by Month” report, it looks like phone inquiry and wrong address queues are being registered as the amount of tickets closed instead of the amount of days it took to close the ticket.](https://clearlyenergy-inc.monday.com/boards/5290716790/pulses/6972624062)

Change Summary:
- Filter reports by query now works. Involved fixing typo in HTTP request parameters and missed variable declaration.
- Updated "Days until ticket closed by month" report to filter out tickets that are not closed-status (closed, resolved, duplicate). 
- Updated report table view to display single-digit decimal precision for all values and blanks for months without closed-status tickets.

**When should this be merged in?**
As soon as possible - NJ was hoping to get their hands on it soon!

**Do you want someone to review this before it gets merged in??**
Yes, first PR in a long time!
