### PR TITLE
Fix attachment upload

### DIFF
--- a/helpdesk/templates/helpdesk/include/clearable_file_input.html
+++ b/helpdesk/templates/helpdesk/include/clearable_file_input.html
@@ -15,7 +15,11 @@
 
     $('#id_{{widget.name}}').on('change', function() {
         src_input = document.getElementById('id_{{widget.name}}');
-        $('#{{ widget.name }}_text').val(src_input.files[0].name);
+        filenames = src_input.files[0].name
+        if (src_input.files.length > 1) {
+            filenames += ` ( + ${src_input.files.length - 1} files)`
+        }
+        $('#{{ widget.name }}_text').val(filenames);
         $('#{{ widget.name }}_interact').toggle();
     });
 

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -274,6 +274,8 @@ $(document).ready(function() {
                 alert("File size exceeds " + {{ helpdesk_settings.HELPDESK_MAX_EMAIL_ATTACHMENT_SIZE }}/1000 + "kB. The file will be uploaded to the ticket, but will not be emailed out.");
             }
             $("#selectedfilename"+browseButtonNum).html(label);
+            $(`<button type="button" title="Remove file" class='btn btn-danger btn-sm ml-2' onClick="deleteFile(${browseButtonNum})"><i class="fa fa-trash"></i></button>
+                `).insertAfter("#selectedfilename"+browseButtonNum);
         };
     });
 
@@ -284,7 +286,13 @@ $(document).ready(function() {
     $(add_button).click(function(e){ //on add input button click
         x++;
         e.preventDefault();
-
+        $(`<div id="file_group${x}">
+            <label class='btn btn-primary btn-sm btn-file'>
+                Browse... 
+                <input type='file' name='attachment' id='file${x}' multiple style='display: none;'/>
+            </label>
+            <span>&nbsp;</span><span id='selectedfilename${x}'>{% trans 'No files selected.' %}</span>
+        </div>`).insertBefore(add_button); //add input box
     });
 
 });
@@ -301,5 +309,14 @@ $(document).on('change', ':file', function() {
     input.trigger('fileselect', [numFiles, label, inputWidgetNum, files]);
 });
 
+function deleteFile(index) {
+    if (index > 0) {
+        $(`#file_group${index}`).remove();
+    } else {
+        $(`#file${index}`).val('');
+        $(`#selectedfilename${index}`).html("{% trans 'No files selected.' %}");
+        $(`#selectedfilename${index}`).next('button').remove(); // removes the delete button
+    }
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
#### What's this PR do?
Fix an issue in which the new ticket form would not accept any new file uploads. File uploads should now work and allow multiples to be uploaded at the same time. The file upload field will now also show the count of how many files were attached.

#### How should this be manually tested?
- Upload multiple files when making a new ticket.
- Upload multiple files at the bottom of an existing ticket
