### PR TITLE
Ticket List: natural time for date columns

### DIFF
--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -1,6 +1,7 @@
 {% extends "helpdesk/base.html" %}
 
 {% load i18n humanize static in_list %}
+{% load natural_time_date %}
 
 {% block helpdesk_title %}{% trans "Tickets" %}{% endblock %}
 
@@ -223,9 +224,9 @@
                                         <td>{% if ticket.get_assigned_to != "Unassigned" %}{{ ticket.get_assigned_to }}{% endif %}</td> {# Remove if statement for "Unassigned" instead of blank #}
                                         <td>{{ ticket.submitter_email }}</td>
                                         <td class="d-none">{{ ticket.paired_count }}</td>
-                                        <td>{{ ticket.created|naturaltime|default_if_none:'' }}</td>
-                                        <td>{{ ticket.last_reply|naturaltime|default_if_none:'' }}</td>
-                                        <td class="d-none">{{ ticket.due_date|naturaltime|default_if_none:'' }}</td>
+                                        <td>{{ ticket.created|naturaltimedate|default_if_none:'' }}</td>
+                                        <td>{{ ticket.last_reply|naturaltimedate|default_if_none:'' }}</td>
+                                        <td class="d-none">{{ ticket.due_date|naturaltimedate|default_if_none:'' }}</td>
                                         <td class="d-none">{{ ticket.time_spent_formatted }}</td>
                                         <td class="d-none">{{ ticket.kbitem.title}}</td>
                                         <td class="d-none">

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -223,9 +223,9 @@
                                         <td>{% if ticket.get_assigned_to != "Unassigned" %}{{ ticket.get_assigned_to }}{% endif %}</td> {# Remove if statement for "Unassigned" instead of blank #}
                                         <td>{{ ticket.submitter_email }}</td>
                                         <td class="d-none">{{ ticket.paired_count }}</td>
-                                        <td>{{ ticket.created|naturalday|default_if_none:'' }}</td>
-                                        <td>{{ ticket.last_reply|naturalday|default_if_none:'' }}</td>
-                                        <td class="d-none">{{ ticket.due_date|naturalday|default_if_none:'' }}</td>
+                                        <td>{{ ticket.created|naturaltime|default_if_none:'' }}</td>
+                                        <td>{{ ticket.last_reply|naturaltime|default_if_none:'' }}</td>
+                                        <td class="d-none">{{ ticket.due_date|naturaltime|default_if_none:'' }}</td>
                                         <td class="d-none">{{ ticket.time_spent_formatted }}</td>
                                         <td class="d-none">{{ ticket.kbitem.title}}</td>
                                         <td class="d-none">

--- a/helpdesk/templatetags/natural_time_date.py
+++ b/helpdesk/templatetags/natural_time_date.py
@@ -1,0 +1,28 @@
+from django import template
+from django.contrib.humanize.templatetags import naturaltime, naturalday
+from datetime import date, datetime
+
+register = template.Library()
+
+@register.filter
+def naturaltimedate(value, arg=None):
+    """
+    For date values that are tomorrow, today or yesterday compared to
+    present day return representing string. Otherwise, return a string
+    formatted according to settings.DATE_FORMAT.
+    """
+    tzinfo = getattr(value, 'tzinfo', None)
+    try:
+        value = date(value.year, value.month, value.day)
+    except AttributeError:
+        # Passed value wasn't a date object
+        return value
+    today = datetime.now(tzinfo).date()
+    delta = value - today
+    if delta.days == 0:
+        return _('today')
+    elif delta.days == 1:
+        return _('tomorrow')
+    elif delta.days == -1:
+        return _('yesterday')
+    return defaultfilters.date(value, arg)

--- a/helpdesk/templatetags/natural_time_date.py
+++ b/helpdesk/templatetags/natural_time_date.py
@@ -1,5 +1,7 @@
 from django import template
-from django.contrib.humanize.templatetags import naturaltime, naturalday
+from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.utils.translation import gettext as _
+from django.template import defaultfilters
 from datetime import date, datetime
 
 register = template.Library()
@@ -12,6 +14,7 @@ def naturaltimedate(value, arg=None):
     formatted according to settings.DATE_FORMAT.
     """
     tzinfo = getattr(value, 'tzinfo', None)
+    original_value = value
     try:
         value = date(value.year, value.month, value.day)
     except AttributeError:
@@ -20,9 +23,9 @@ def naturaltimedate(value, arg=None):
     today = datetime.now(tzinfo).date()
     delta = value - today
     if delta.days == 0:
-        return _('today')
+        return naturaltime(original_value)
     elif delta.days == 1:
         return _('tomorrow')
     elif delta.days == -1:
         return _('yesterday')
-    return defaultfilters.date(value, arg)
+    return defaultfilters.date(original_value, arg)


### PR DESCRIPTION
#### Any background context you want to provide?
Jurisdictions may receive many helpdesk tickets in a day. Currently there isn't a clear way to compare the age of tickets within a particular day.

#### What's this PR do?
Updates the helpdesk ticket list to use natural (humanized) time for datetimes that are today, and fallback to displaying the date for other dates.

#### How should this be manually tested?
Open the ticket list and create a new ticket. The "created" column should show an "X minutes ago" value.

#### What are the relevant tickets?
https://clearlyenergy-inc.monday.com/boards/7029256041/pulses/7318907575

#### Screenshots (if appropriate)
Before
![image](https://github.com/user-attachments/assets/89b20b94-bde4-473a-95d2-1387d2d5d121)
After
![image](https://github.com/user-attachments/assets/32859f7a-192c-48cc-8a3b-017d27a0812e)

