### PR TITLE
Reports page error: detailed average by month link

### DIFF
--- a/helpdesk/templates/helpdesk/report_index.html
+++ b/helpdesk/templates/helpdesk/report_index.html
@@ -27,11 +27,28 @@
                 <tbody>
                     <tr>
                         <td>{% trans "Average number of days until ticket is closed (all tickets): " %}</td>
-                        <td><strong style="color: red;">{{ basic_ticket_stats.average_nbr_days_until_ticket_closed }}</strong>.</td>
+                        <td>
+                            {% if number_closed == 0 %}
+                                {% trans "There are no closed tickets." %}
+                            {% else %}
+                                <strong style="color: red;">{{ basic_ticket_stats.average_nbr_days_until_ticket_closed }}</strong>.
+                            {% endif %}
+                        </td>
                     </tr>
                     <tr>
                         <td>{% trans "Average number of days until ticket is closed (tickets opened in last 60 days): " %}</td>
-                        <td><strong style="color: red;">{{ basic_ticket_stats.average_nbr_days_until_ticket_closed_last_60_days }}</strong>. {% trans "Click" %} <strong><a href="{% url 'helpdesk:report_index' %}daysuntilticketclosedbymonth">here</a></strong> {% trans "for detailed average by month." %} </td>
+                        <td>
+                            {% if number_closed_last_60__days == 0 %}
+                                {% trans "There are no closed tickets in the last 60 days." %}
+                            {% else %}
+                                <strong style="color: red;">{{ basic_ticket_stats.average_nbr_days_until_ticket_closed_last_60_days }}</strong>. 
+                                {% trans "Click" %} 
+                                <strong>
+                                    <a href="{% url 'helpdesk:report_index' %}daysuntilticketclosedbymonth">{% trans "here" %}</a>
+                                </strong>
+                                {% trans "for detailed average by month." %}
+                            {% endif %}
+                        </td>
                     </tr>
                 </tbody>
             </table>

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -2264,6 +2264,8 @@ def report_index(request):
     Queues = user_queues if user_queues else Queue.objects.all()
 
     dash_tickets = []
+    number_closed = 0
+    number_closed_last_60__days = 0
     for queue in Queues:
         dash_ticket = {
             'queue': queue.id,
@@ -2271,13 +2273,18 @@ def report_index(request):
             'open': queue.ticket_set.filter(status__in=[1, 2]).count(),
             'resolved': queue.ticket_set.filter(status=3).count(),
             'closed': queue.ticket_set.filter(status=4).count(),
+            'closed_last_60_days': queue.ticket_set.filter(status=4,created__gte=timezone.now() - timedelta(days=60)).count(),
             'time_spent': format_time_spent(queue.time_spent),
             'dedicated_time': format_time_spent(queue.dedicated_time)
         }
         dash_tickets.append(dash_ticket)
+        number_closed += dash_ticket['closed']
+        number_closed_last_60__days += dash_ticket['closed_last_60_days']
 
     return render(request, 'helpdesk/report_index.html', {
         'number_tickets': number_tickets,
+        'number_closed': number_closed,
+        'number_closed_last_60__days': number_closed_last_60__days,
         'saved_query': saved_query,
         'basic_ticket_stats': basic_ticket_stats,
         'dash_tickets': dash_tickets,


### PR DESCRIPTION
The issue appears to occur when number_tickets > 0 but closed_tickets == 0.

- added total counts for closed tickets/closed tickets in the last 60 days.
- if the total number of closed tickets is 0, hide the detailed average link and show the message.

![image](https://github.com/user-attachments/assets/b40a0200-7c29-4b17-81e2-51cb83dbe145)
