### PR TITLE
Allow for helpdesk ticket response window to be made larger

### DIFF
--- a/helpdesk/templates/helpdesk/include/comment_md_preview.html
+++ b/helpdesk/templates/helpdesk/include/comment_md_preview.html
@@ -9,7 +9,7 @@
             </li>
         </ul>
     </div>
-    <div class="card-body tab-content" style='max-height: 50vh; overflow-y: auto'>
+    <div class="card-body tab-content" style='overflow-y: auto'>
         <div id="comment_edit" class="tab-pane active">
             <textarea class="form-control" name="comment" id="commentBox" cols="40" rows="10" spellcheck="true" data-ms-editor="true"></textarea>
         </div>


### PR DESCRIPTION
#### Any background context you want to provide?
Comment for whoever works on this: You can drag the edge of the comment box to make it wider, but interestingly the containing panel can only be so large and eventually you have to scroll within the panel to see more of the text box.

#### What are the relevant tickets?
https://clearlyenergy-inc.monday.com/boards/7029256041/views/160742034/pulses/7848244043
#### Screenshots (if appropriate)
https://github.com/user-attachments/assets/21b7c4e6-21f9-4619-994a-f688e1705b3f

