### PR TITLE
update: ticket bulk replies

### DIFF
--- a/helpdesk/templates/helpdesk/include/bulk_replies.html
+++ b/helpdesk/templates/helpdesk/include/bulk_replies.html
@@ -1,0 +1,31 @@
+{% load i18n humanize %}
+
+<div class="modal fade" id="bulkRepliesModal" tabindex="-1" role="dialog" aria-labelledby="bulkRepliesModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="bulkRepliesModalLabel">Bulk Replies</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <fieldset>
+                    <dl>
+                        {% if preset_replies %}
+                        <dd><label for='id_preset'><b>{% trans "Select a Preset Reply" %}</b></label>
+                        <select name='preset' id='id_preset' class='form-control'><option value=''>------</option>{% for preset in preset_replies %}<option value='{{ preset.id }}'>{{ preset.name }}</option>{% endfor %}</select><br/>
+                        </dd>
+                        {% endif %}
+                        <dd><label for='id_public'><input type='checkbox' id='id_public' name='public' />&nbsp; <b>{% trans 'Make this update public?' %}</b></dd>
+                        <dd class='form_help_text'>{% trans "If public, an email will be sent to the submitter, primary contact, copied nonusers, and any other email addresses listed on the form.<br>If private, an email will only be sent to the assigned staff owner and internal users. Use this to leave internal comments, questions, and flags. Responses will <i>not</i> be sent to the original sender. " %}</dd>
+                    </dl>
+                </fieldset>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                <button type="button"  class="btn btn-danger" onclick="onBulkRepliesConfirm()">Confirm</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -85,6 +85,7 @@
                         <option value="take">Take (Assign to me)</option>
                         <option value="delete">Delete</option><option value="merge">Merge</option>
                         <option value="export">Export</option><option value="pair">Pair to BEAM inventory</option>
+                        <option value="bulk_reply">Bulk Reply</option>
                         <optgroup label="Close">
                             <option value="close">Close (Don't Send E-Mail)</option>
                             <option value="close_public">Close (Send E-Mail)</option>
@@ -97,7 +98,7 @@
                         </optgroup>
                     </select>
                     <div class="input-group-append">
-                        <button id="massActionButton" type="button" onclick="massUpdate()" class="btn btn-outline-secondary" disabled>Run Action <i class="fa fa-arrow-circle-right mr-1"></i></button>
+                        <button id="massActionButton" type="button" onclick="onMassActionClick()" class="btn btn-outline-secondary" disabled>Run Action <i class="fa fa-arrow-circle-right mr-1"></i></button>
                     </div>
                 </div>
                 <!-- Pass vars to View for exporting to work Properly -->
@@ -155,6 +156,10 @@
             </div>
         </div>
     </div>
+
+
+    {% include 'helpdesk/include/bulk_replies.html' with preset_replies=preset_replies %}
+
     <!-- / Action Toolbar -->
     <div class="row">
     <div class="col-sm-8 col-md-9 col-lg-10 order-1 pl-3">
@@ -595,14 +600,38 @@
         }
     }
 
+    function onMassActionClick() {
+        const mass_action = $('#id_mass_action').val();
+        
+        if (mass_action == 'bulk_reply') {
+            $('#bulkRepliesModal').modal('show');
+            return;
+        }
+        const form = document.forms['ticket_mass_update'];
+        const formData = new FormData(form);
+        massUpdate(formData); 
+    }
+
+    function onBulkRepliesConfirm() {
+        const preset_id = $("#id_preset").val();
+        const id_public = $('#id_public').prop('checked');
+        const form = document.forms['ticket_mass_update'];
+        let formData = new FormData(form);
+        formData.append('preset_id', preset_id);
+        formData.append('public', id_public);
+        
+        massUpdate(formData); 
+        $('#bulkRepliesModal').modal('hide');
+    }
+
     // Perform ticket mass update asynchronously, then
     // reload page with current query and ticket view preferences
-    function massUpdate() {
+    function massUpdate(formData) {
         let refreshFlag = true;
         $.ajax({
             url: "{% url 'helpdesk:mass_update' %}",
             type: 'POST',
-            data: new FormData(document.forms['ticket_mass_update']),
+            data: formData,
             processData: false,
             contentType: false,
             xhrFields: {

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -29,6 +29,7 @@ from django.utils.html import escape
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic.edit import FormView, UpdateView
+from django.template import engines
 
 from helpdesk.forms import CUSTOMFIELD_DATE_FORMAT, CUSTOMFIELD_DATETIME_FORMAT, PreviewWidget
 from helpdesk.query import (
@@ -1487,6 +1488,53 @@ def mass_update(request):
     elif action == 'take':
         user = request.user
         action = 'assign'
+    elif action == 'bulk_reply':
+        date = timezone.now()
+        preset_template_id = request.POST.get('preset_id')
+        is_public = request.POST.get('public') == 'true'
+
+        org = request.user.default_organization.helpdesk_organization
+        user = request.user
+        preset_template = PreSetReply.objects.get(id=preset_template_id)
+        ticket_list = Ticket.objects.filter(id__in=tickets)
+        # breakpoint()
+        for ticket in ticket_list:
+            context = None
+            context = safe_template_context(ticket)
+            context['private'] = False
+            comment = preset_template.body
+            template_func = engines['django'].from_string
+            comment = comment.replace('{%', 'X-HELPDESK-COMMENT-VERBATIM').replace('%}', 'X-HELPDESK-COMMENT-ENDVERBATIM')
+            comment = comment.replace('X-HELPDESK-COMMENT-VERBATIM', '{% verbatim %}{%').replace('X-HELPDESK-COMMENT-ENDVERBATIM', '%}{% endverbatim %}')
+            comment = template_func(comment).render(context)
+            f = FollowUp.objects.create(
+                ticket=ticket,
+                title='Comment',
+                date=date,
+                public=is_public,
+                comment=comment,
+                message_id=None,
+                user=user
+            )
+            # if setting the ticket's status:
+            # f.new_status = Ticket.CLOSED_STATUS
+            # ticket.status = Ticket.CLOSED_STATUS
+            # ticket.save()
+            # f.save()
+            context.update(comment=f.comment)
+            roles = {'submitter': ('updated_submitter', context),
+                'assigned_to': ('updated_owner', context),
+                'cc_users': ('updated_cc_user', context),
+                'queue_updated': ('updated_cc_user', context)}
+            if ticket.queue.enable_notifications_on_email_events:
+                roles['cc_public'] = ('updated_cc_public', context)
+                roles['extra'] = ('updated_cc_public', context)
+            ticket.send_ticket_mail(
+                roles,
+                organization=org,
+                fail_silently=True,
+                source="updated (script)"
+            )
     elif action == 'merge':
         # Redirect to the Merge View with selected tickets id in the GET request
         return redirect(
@@ -2050,6 +2098,8 @@ def ticket_list(request):
         form_choices=form_choices,
         priority_choices=Ticket.PRIORITY_CHOICES,
         status_choices=Ticket.STATUS_CHOICES,
+        preset_replies=PreSetReply.objects.filter(organization=org),
+        # .filter(Q(queues=ticket.queue) | Q(queues__isnull=True)),
         tag_choices=tag_choices,
         urlsafe_query=urlsafe_query,
         user_saved_queries=user_saved_queries,


### PR DESCRIPTION
#### What's this PR do?
Add an option to the ticket list Action dropdown to add a preset reply to the selected tickets in the list. Ideally, running that action should create a pop-up window (or a different page) where the user can select the pre-set reply and mark whether they want it public or private (i.e. who should get emails for it). Add an additional help text that warns that every person on the ticket will get an email.

#### What are the relevant tickets?
https://clearlyenergy-inc.monday.com/boards/7029256041/views/160742034/pulses/7145102257

#### Screenshots (if appropriate)

Uploading bulk-reply.mp4…

