### PR TITLE
update: KB article attachments delete file

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1247,6 +1247,22 @@ class KBIAttachment(Attachment):
             if not os.path.exists(att_path):
                 os.makedirs(att_path, 0o777)
         return os.path.join(path, filename)
+    
+    def delete(self, *args, **kwargs):
+        if settings.DEFAULT_FILE_STORAGE == "django.core.files.storage.FileSystemStorage":
+            if self.file and os.path.isfile(self.file.path):
+                os.remove(self.file.path)
+            
+            # Optionally remove the directory if it's empty
+            directory = os.path.dirname(self.file.path)
+            if os.path.exists(directory) and not os.listdir(directory):
+                os.rmdir(directory)
+        else:
+            # For other storage backends, use the default storage API
+            if self.file:
+                self.file.delete(save=False)
+
+        super().delete(*args, **kwargs)
 
 
 class PreSetReply(models.Model):

--- a/helpdesk/views/kb.py
+++ b/helpdesk/views/kb.py
@@ -385,9 +385,12 @@ def edit_article(request, slug, pk, iframe=False):
 
                     if cf['file']:
                         attach = cf['id'] if cf['id'] else KBIAttachment()
+                        # To Do: Verify if reassigning the KBItem ID is redundant since it is already set in upload_attachment(). 
+                        # Consider using FILE_UPLOAD_TEMP_DIR and TemporaryUploadedFile to handle cases where users abandon the form after file upload.
+                        # if isinstance(uploaded_file, TemporaryUploadedFile):
+                        #      pass:
                         attach.kbitem = item
-                        attach.file = cf['file']  # .file
-                        # attach.filename = cf['file']
+                        # attach.file = cf['file']  # This line will assign file to attachment again and duplicates the file in the storage.
 
                         attach.save()
         if manage:


### PR DESCRIPTION
#### Any background context you want to provide?
Deleting a file uploaded to a knowledgebase article doesn't actually delete it from BEAM's files.

#### What are the relevant tickets?
https://clearlyenergy-inc.monday.com/boards/7029256041/views/160742034/pulses/8248727165

#### Screenshots (if appropriate)

https://github.com/user-attachments/assets/ab22628e-cf59-43a6-8a73-f056e50a9207

